### PR TITLE
Add eso-creds-refresher CronJob

### DIFF
--- a/docs/examples/cue.mod/usr/k8s.io/api/batch/v1/types.cue
+++ b/docs/examples/cue.mod/usr/k8s.io/api/batch/v1/types.cue
@@ -1,0 +1,11 @@
+package v1
+
+#CronJob: {
+  apiVersion: "batch/v1"
+  kind: "CronJob"
+}
+
+#Job: {
+  apiVersion: "batch/v1"
+  kind: "Job"
+}

--- a/docs/examples/schema.cue
+++ b/docs/examples/schema.cue
@@ -5,6 +5,7 @@ import (
 	ksv1 "kustomize.toolkit.fluxcd.io/kustomization/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	es "external-secrets.io/externalsecret/v1beta1"
 	ss "external-secrets.io/secretstore/v1beta1"
 	"encoding/yaml"
@@ -60,6 +61,8 @@ _apiVersion: "holos.run/v1alpha1"
 #ConfigMap:          #NamespaceObject & corev1.#ConfigMap
 #ServiceAccount:     #NamespaceObject & corev1.#ServiceAccount
 #Pod:                #NamespaceObject & corev1.#Pod
+#Job:                #NamespaceObject & batchv1.#Job
+#CronJob:            #NamespaceObject & batchv1.#CronJob
 
 // Flux Kustomization CRDs
 #Kustomization: #NamespaceObject & ksv1.#Kustomization & {


### PR DESCRIPTION
This patch adds the `eso-creds-refresher` CronJob which executes every 8 hours in the holos-system namespace of each workload cluster.  The job creates Secrets with a `token` field representing the id token credential for a SecretStore to use when synchronizing secrets to and from the provisioner cluster.

Service accounts in the provisioner cluster are selected with selector=holos.run/job.name=eso-creds-refresher.

Each selected service account has a token issued with a 12 hour expiration ttl and is stored in a Secret matching the service account name in the same namespace in the workload cluster.

The job takes about 25 seconds to run once the image is cached on the node.
