### PR TITLE
(#10) Add tests for holos get secrets command

### DIFF
--- a/cmd/holos/main.go
+++ b/cmd/holos/main.go
@@ -1,28 +1,10 @@
 package main
 
 import (
-	"context"
-	"errors"
 	"github.com/holos-run/holos/pkg/cli"
-	"github.com/holos-run/holos/pkg/holos"
-	"github.com/holos-run/holos/pkg/wrapper"
-	"log/slog"
 	"os"
 )
 
 func main() {
-	cfg := holos.New()
-	slog.SetDefault(cfg.Logger())
-	ctx := context.Background()
-	if err := cli.New(cfg).ExecuteContext(ctx); err != nil {
-		log := cfg.NewTopLevelLogger()
-		var errAt *wrapper.ErrorAt
-		const msg = "could not execute"
-		if ok := errors.As(err, &errAt); ok {
-			log.ErrorContext(ctx, msg, "err", errAt.Unwrap(), "loc", errAt.Source.Loc())
-		} else {
-			log.ErrorContext(ctx, msg, "err", err)
-		}
-		os.Exit(1)
-	}
+	os.Exit(cli.MakeMain()())
 }

--- a/cmd/holos/main_test.go
+++ b/cmd/holos/main_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"github.com/holos-run/holos/pkg/cli"
+	"github.com/rogpeppe/go-internal/testscript"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(testscript.RunMain(m, map[string]func() int{
+		"holos": cli.MakeMain(),
+	}))
+}
+
+func TestGetSecrets(t *testing.T) {
+	testscript.Run(t, testscript.Params{
+		Dir: "testdata",
+	})
+}

--- a/cmd/holos/testdata/version.txt
+++ b/cmd/holos/testdata/version.txt
@@ -1,0 +1,5 @@
+exec holos --version
+# want version with no v on stdout
+stdout -count=1 '^\d+\.\d+\.\d+$'
+# want nothing on stderr
+! stderr .

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/emicklei/proto v1.10.0 // indirect
+	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/go-logr/logr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
@@ -38,7 +39,9 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0-rc4 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/protocolbuffers/txtpbfmt v0.0.0-20230328191034-3462fbc510c0 // indirect
+	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/oauth2 v0.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxER
 github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/emicklei/proto v1.10.0 h1:pDGyFRVV5RvV+nkBK9iy3q67FBy9Xa7vwrOTE+g5aGw=
 github.com/emicklei/proto v1.10.0/go.mod h1:rn1FgRS/FANiZdD2djyH7TMA9jdRDcYQ9IEN9yvjX0A=
+github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
+github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/go-logr/logr v1.3.0 h1:2y3SDp0ZXuc6/cjLSZ+Q3ir+QB9T/iG5yYRXqsagWSY=
 github.com/go-logr/logr v1.3.0/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-openapi/jsonpointer v0.19.6 h1:eCs3fxoIi3Wh6vtgmLTOjdhSpiqphQ+DaPn38N2ZdrE=
@@ -88,12 +90,16 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0-rc4 h1:oOxKUJWnFC4YGHCCMNql1x4YaDfYBTS5Y4x/Cgeo1E0=
 github.com/opencontainers/image-spec v1.1.0-rc4/go.mod h1:X4pATf0uXsnn3g5aiGIsVnJBR4mxhKzfwmvK/B2NTm8=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/protocolbuffers/txtpbfmt v0.0.0-20230328191034-3462fbc510c0 h1:sadMIsgmHpEOGbUs6VtHBXRR1OHevnj7hLx9ZcdNGW4=
 github.com/protocolbuffers/txtpbfmt v0.0.0-20230328191034-3462fbc510c0/go.mod h1:jgxiZysxFPM+iWKwQwPR+y+Jvo54ARd4EisXxKYpB5c=
 github.com/rogpeppe/go-internal v1.11.1-0.20231026093722-fa6a31e0812c h1:fPpdjePK1atuOg28PXfNSqgwf9I/qD1Hlo39JFwKBXk=
 github.com/rogpeppe/go-internal v1.11.1-0.20231026093722-fa6a31e0812c/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
+github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
+github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
 github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=

--- a/pkg/cli/main.go
+++ b/pkg/cli/main.go
@@ -1,0 +1,35 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"github.com/holos-run/holos/pkg/holos"
+	"github.com/holos-run/holos/pkg/wrapper"
+	"log/slog"
+)
+
+// MakeMain makes a main function for the cli or tests.
+func MakeMain(options ...holos.Option) func() int {
+	return func() (exitCode int) {
+		cfg := holos.New(options...)
+		slog.SetDefault(cfg.Logger())
+		ctx := context.Background()
+		if err := New(cfg).ExecuteContext(ctx); err != nil {
+			return handleError(ctx, err, cfg)
+		}
+		return 0
+	}
+}
+
+// handleError is the top level error handler that unwraps and logs errors.
+func handleError(ctx context.Context, err error, hc *holos.Config) (exitCode int) {
+	log := hc.NewTopLevelLogger()
+	var errAt *wrapper.ErrorAt
+	const msg = "could not execute"
+	if ok := errors.As(err, &errAt); ok {
+		log.ErrorContext(ctx, msg, "err", errAt.Unwrap(), "loc", errAt.Source.Loc())
+	} else {
+		log.ErrorContext(ctx, msg, "err", err)
+	}
+	return 1
+}

--- a/pkg/cli/secret/create.go
+++ b/pkg/cli/secret/create.go
@@ -47,10 +47,12 @@ func makeCreateRunFunc(hc *holos.Config, cfg *config) command.RunFunc {
 			Data: make(secretData),
 		}
 
-		clusterPrefix := fmt.Sprintf("%s-", *cfg.cluster)
-		if !strings.HasPrefix(secretName, clusterPrefix) {
-			const msg = "missing cluster name prefix"
-			log.WarnContext(ctx, msg, "have", secretName, "want", clusterPrefix)
+		if *cfg.cluster != "" {
+			clusterPrefix := fmt.Sprintf("%s-", *cfg.cluster)
+			if !strings.HasPrefix(secretName, clusterPrefix) {
+				const msg = "missing cluster name prefix"
+				log.WarnContext(ctx, msg, "have", secretName, "want", clusterPrefix)
+			}
 		}
 
 		for _, file := range cfg.files {

--- a/pkg/cli/secret/secret.go
+++ b/pkg/cli/secret/secret.go
@@ -18,6 +18,7 @@ type config struct {
 	dryRun    *bool
 	cluster   *string
 	namespace *string
+	extractTo *string
 }
 
 func newConfig() (*config, *flag.FlagSet) {

--- a/pkg/cli/secret/secret_test.go
+++ b/pkg/cli/secret/secret_test.go
@@ -1,0 +1,81 @@
+package secret_test
+
+import (
+	"github.com/holos-run/holos/pkg/cli"
+	"github.com/holos-run/holos/pkg/holos"
+	"github.com/rogpeppe/go-internal/testscript"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"testing"
+	"time"
+)
+
+const clientsetKey = "clientset"
+
+var secret = v1.Secret{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       "Secret",
+		APIVersion: "v1",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "k2-talos",
+		Namespace: "secrets",
+		Labels: map[string]string{
+			"holos.run/owner.name":  "jeff",
+			"holos.run/secret.name": "k2-talos",
+		},
+		CreationTimestamp: metav1.Time{
+			Time: time.Date(2020, time.January, 1, 0, 0, 0, 0, time.UTC),
+		},
+	},
+	Data: map[string][]byte{
+		"secrets.yaml": []byte("content: secret\n"),
+	},
+	Type: "Opaque",
+}
+
+// cmdHolos executes the holos root command with a kubernetes.Interface that
+// persists for the duration of the testscript. holos is NOT executed in a
+// subprocess, the current working directory is not and should not be changed.
+// Take care to read and write to $WORK in the test scripts using flags.
+func cmdHolos(ts *testscript.TestScript, neg bool, args []string) {
+	clientset, ok := ts.Value(clientsetKey).(kubernetes.Interface)
+	if clientset == nil || !ok {
+		ts.Fatalf("missing kubernetes.Interface")
+	}
+
+	cfg := holos.New(
+		holos.ProvisionerClientset(clientset),
+		holos.Stdout(ts.Stdout()),
+		holos.Stderr(ts.Stderr()),
+	)
+
+	cmd := cli.New(cfg)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	if neg {
+		if err == nil {
+			ts.Fatalf("want: error\nhave: %v", err)
+		} else {
+			ts.Logf("want: error\nhave: %v", err)
+		}
+	} else {
+		ts.Check(err)
+	}
+}
+
+func TestSecrets(t *testing.T) {
+	// Add TestWork: true to the Params to keep the $WORK directory around.
+	testscript.Run(t, testscript.Params{
+		Dir: "testdata",
+		Setup: func(env *testscript.Env) error {
+			env.Values[clientsetKey] = fake.NewSimpleClientset(&secret)
+			return nil
+		},
+		Cmds: map[string]func(ts *testscript.TestScript, neg bool, args []string){
+			"holos": cmdHolos,
+		},
+	})
+}

--- a/pkg/cli/secret/testdata/create_secret_from_dir.txt
+++ b/pkg/cli/secret/testdata/create_secret_from_dir.txt
@@ -1,0 +1,22 @@
+# Create the secret
+holos create secret directory --from-file=$WORK/want
+stderr 'created: directory-..........'
+stderr 'secret=directory-..........'
+stderr 'name=directory'
+stderr 'namespace=secrets'
+! stderr 'WRN'
+
+# Get the secret back
+mkdir have
+holos get secret directory --extract-all --extract-to=$WORK/have
+stderr 'wrote: .*/have/one.yaml'
+stderr 'wrote: .*/have/two.yaml'
+
+# Compare the secrets
+cmp want/one.yaml have/one.yaml
+cmp want/two.yaml have/two.yaml
+
+-- want/one.yaml --
+content: one
+-- want/two.yaml --
+content: two

--- a/pkg/cli/secret/testdata/create_secret_from_file.txt
+++ b/pkg/cli/secret/testdata/create_secret_from_file.txt
@@ -1,0 +1,14 @@
+# Create the secret.
+holos create secret k3-talos --from-file $WORK/secrets.yaml
+
+# Want info log attributes.
+stderr 'created: k3-talos-..........'
+stderr 'secret=k3-talos-..........'
+stderr 'name=k3-talos'
+stderr 'namespace=secrets'
+
+# Want no warnings.
+! stderr 'WRN'
+
+-- secrets.yaml --
+content: hello

--- a/pkg/cli/secret/testdata/create_secret_namespace.txt
+++ b/pkg/cli/secret/testdata/create_secret_namespace.txt
@@ -1,0 +1,14 @@
+# Create the secret.
+holos create secret k3-talos --namespace=jeff --from-file $WORK/secrets.yaml
+stderr 'created: k3-talos-..........'
+stderr 'secret=k3-talos-..........'
+stderr 'name=k3-talos'
+
+# Want specified namespace.
+stderr 'namespace=jeff'
+
+# Want no warnings.
+! stderr 'WRN'
+
+-- secrets.yaml --
+content: hello

--- a/pkg/cli/secret/testdata/create_secret_warns.txt
+++ b/pkg/cli/secret/testdata/create_secret_warns.txt
@@ -1,0 +1,11 @@
+# Create the secret.
+holos create secret k3-talos --cluster-name=k2 --from-file $WORK/secrets.yaml
+stderr 'created: k3-talos-..........'
+
+# Want a warning about the cluster name prefix.
+stderr 'missing cluster name prefix'
+stderr 'have=k3-talos'
+stderr 'want=k2-'
+
+-- secrets.yaml --
+content: hello

--- a/pkg/cli/secret/testdata/get_secret_extract_all.txt
+++ b/pkg/cli/secret/testdata/get_secret_extract_all.txt
@@ -1,0 +1,10 @@
+# Get and extract the secret
+holos get secrets k2-talos --extract-all --extract-to=$WORK
+! stdout .
+stderr 'wrote: .*/secrets\.yaml'
+
+# Check the secret keys
+cmp want.secrets.yaml secrets.yaml
+
+-- want.secrets.yaml --
+content: secret

--- a/pkg/cli/secret/testdata/get_secret_print.txt
+++ b/pkg/cli/secret/testdata/get_secret_print.txt
@@ -1,0 +1,3 @@
+holos get secrets k2-talos --print-key=secrets.yaml
+stdout -count=1 '^content: secret$'
+! stderr .

--- a/pkg/cli/secret/testdata/get_secrets.txt
+++ b/pkg/cli/secret/testdata/get_secrets.txt
@@ -1,0 +1,3 @@
+holos get secrets
+stdout '^k2-talos$'
+! stderr .


### PR DESCRIPTION
This patch adds basic test data to run integration level tests on the holos cli command.  Tests are structured similar to how the go and cue maintainers test their own cli tools using the [testscript](https://pkg.go.dev/github.com/rogpeppe/go-internal/testscript) package.

Fixture data is loaded into a fake kubernetes.Clientset
