### PR TITLE
(#48) Custom PGO Certs for Zitadel

### DIFF
--- a/docs/examples/platforms/reference/clusters/provisioner/iam/iam.cue
+++ b/docs/examples/platforms/reference/clusters/provisioner/iam/iam.cue
@@ -1,0 +1,10 @@
+package holos
+
+// Components under this directory are part of this collection
+#InputKeys: project: "iam"
+
+// Shared dependencies for all components in this collection.
+#DependsOn: _Namespaces
+
+// Common Dependencies
+_Namespaces: Namespaces: name: "\(#StageName)-secrets-namespaces"

--- a/docs/examples/platforms/reference/clusters/provisioner/iam/zitadel/postgres-certs/postgres-certs.cue
+++ b/docs/examples/platforms/reference/clusters/provisioner/iam/zitadel/postgres-certs/postgres-certs.cue
@@ -1,0 +1,101 @@
+package holos
+
+// Manage an Issuer for the database.
+
+// Both cockroach and postgres handle tls database connections with cert manager
+// PGO: https://github.com/CrunchyData/postgres-operator-examples/tree/main/kustomize/certmanager/certman
+// CRDB: https://github.com/cockroachdb/helm-charts/blob/3dcf96726ebcfe3784afb526ddcf4095a1684aea/README.md?plain=1#L196-L201
+
+// Refer to [Using Cert Manager to Deploy TLS for Postgres on Kubernetes](https://www.crunchydata.com/blog/using-cert-manager-to-deploy-tls-for-postgres-on-kubernetes)
+
+#InputKeys: component: "postgres-certs"
+
+let SelfSigned = "\(_DBName)-selfsigned"
+let RootCA = "\(_DBName)-root-ca"
+let Orgs = ["Database"]
+
+#KubernetesObjects & {
+	apiObjects: {
+		// Put everything in the target namespace.
+		[_]: {
+			[Name=_]: {
+				metadata: name:      Name
+				metadata: namespace: #TargetNamespace
+			}
+		}
+		Issuer: {
+			"\(SelfSigned)": #Issuer & {
+				_description: "Self signed issuer to issue ca certs"
+				metadata: name: SelfSigned
+				spec: selfSigned: {}
+			}
+			"\(RootCA)": #Issuer & {
+				_description: "Root signed intermediate ca to issue mtls database certs"
+				metadata: name: RootCA
+				spec: ca: secretName: RootCA
+			}
+		}
+		Certificate: {
+			"\(RootCA)": #Certificate & {
+				_description: "Root CA cert for database"
+				metadata: name: RootCA
+				spec: {
+					commonName: RootCA
+					isCA:       true
+					issuerRef: group:      "cert-manager.io"
+					issuerRef: kind:       "Issuer"
+					issuerRef: name:       SelfSigned
+					privateKey: algorithm: "ECDSA"
+					privateKey: size:      256
+					secretName: RootCA
+					subject: organizations: Orgs
+				}
+			}
+			"\(_DBName)-primary-tls": #DatabaseCert & {
+				// PGO managed name is "<cluster name>-cluster-cert" e.g. zitadel-cluster-cert
+				spec: {
+					commonName: "\(_DBName)-primary"
+					dnsNames: [
+						commonName,
+						"\(commonName).\(#TargetNamespace)",
+						"\(commonName).\(#TargetNamespace).svc",
+						"\(commonName).\(#TargetNamespace).svc.cluster.local",
+						"localhost",
+						"127.0.0.1",
+					]
+					usages: ["digital signature", "key encipherment"]
+				}
+			}
+			"\(_DBName)-repl-tls": #DatabaseCert & {
+				spec: {
+					commonName: "_crunchyrepl"
+					dnsNames: [commonName]
+					usages: ["digital signature", "key encipherment"]
+				}
+			}
+			"\(_DBName)-client-tls": #DatabaseCert & {
+				spec: {
+					commonName: "\(_DBName)-client"
+					dnsNames: [commonName]
+					usages: ["digital signature", "key encipherment"]
+				}
+			}
+		}
+	}
+}
+
+#DatabaseCert: #Certificate & {
+	metadata: name:      string
+	metadata: namespace: #TargetNamespace
+	spec: {
+		duration:    "2160h" // 90d
+		renewBefore: "360h"  // 15d
+		issuerRef: group:      "cert-manager.io"
+		issuerRef: kind:       "Issuer"
+		issuerRef: name:       RootCA
+		privateKey: algorithm: "ECDSA"
+		privateKey: size:      256
+		secretName: metadata.name
+		subject: organizations: Orgs
+	}
+}

--- a/docs/examples/platforms/reference/clusters/provisioner/iam/zitadel/postgres-certs/readme.md
+++ b/docs/examples/platforms/reference/clusters/provisioner/iam/zitadel/postgres-certs/readme.md
@@ -1,0 +1,7 @@
+# Database Certs
+
+This component issues postgres certificates from the provisioner cluster using certmanager.
+
+The purpose is to define customTLSSecret and customReplicationTLSSecret to provide certs that allow the standby to authenticate to the primary. For this type of standby, you must use custom TLS.
+
+Refer to the PGO [Streaming Standby](https://access.crunchydata.com/documentation/postgres-operator/latest/tutorials/backups-disaster-recovery/disaster-recovery#streaming-standby) tutorial.

--- a/docs/examples/platforms/reference/clusters/provisioner/iam/zitadel/zitadel.cue
+++ b/docs/examples/platforms/reference/clusters/provisioner/iam/zitadel/zitadel.cue
@@ -1,0 +1,6 @@
+package holos
+
+#TargetNamespace: #InstancePrefix + "-zitadel"
+
+// _DBName is the database name used across multiple holos components in this project
+_DBName: "zitadel"

--- a/docs/examples/platforms/reference/clusters/workload/cloud/iam/zitadel/postgres-certs/postgres-certs.cue
+++ b/docs/examples/platforms/reference/clusters/workload/cloud/iam/zitadel/postgres-certs/postgres-certs.cue
@@ -1,0 +1,13 @@
+package holos
+
+#InputKeys: component: "postgres-certs"
+#KubernetesObjects & {
+	apiObjects: {
+		ExternalSecret: {
+			"\(_DBName)-primary-tls": _
+			"\(_DBName)-repl-tls":    _
+			"\(_DBName)-client-tls":  _
+			"\(_DBName)-root-ca":     _
+		}
+	}
+}

--- a/docs/examples/platforms/reference/clusters/workload/cloud/iam/zitadel/postgres/postgres.cue
+++ b/docs/examples/platforms/reference/clusters/workload/cloud/iam/zitadel/postgres/postgres.cue
@@ -1,6 +1,7 @@
 package holos
 
-#InputKeys: component: "postgres"
+#InputKeys: component:        "postgres"
+#DependsOn: "postgres-certs": _
 
 let Cluster = #Platform.clusters[#ClusterName]
 let S3Secret = "pgo-s3-creds"
@@ -18,6 +19,10 @@ let ZitadelAdmin = "\(_DBName)-admin"
 			spec: {
 				image:           "registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-16.2-0"
 				postgresVersion: 16
+				// Custom certs are necessary for streaming standby replication which we use to replicate between two regions.
+				// Refer to https://access.crunchydata.com/documentation/postgres-operator/latest/tutorials/backups-disaster-recovery/disaster-recovery#streaming-standby
+				customTLSSecret: name:            "\(_DBName)-primary-tls"
+				customReplicationTLSSecret: name: "\(_DBName)-repl-tls"
 				// Refer to https://access.crunchydata.com/documentation/postgres-operator/latest/references/crd/5.5.x/postgrescluster#postgresclusterspecusersindex
 				users: [
 					{name: ZitadelUser},

--- a/docs/examples/platforms/reference/clusters/workload/cloud/iam/zitadel/zitadel/values.holos.cue
+++ b/docs/examples/platforms/reference/clusters/workload/cloud/iam/zitadel/zitadel/values.holos.cue
@@ -43,17 +43,22 @@ package holos
 			valueFrom: secretKeyRef: name: "\(_DBName)-pguser-\(_DBName)-admin"
 			valueFrom: secretKeyRef: key:  "password"
 		},
+		// CA Cert issued by PGO which issued the pgbouncer tls cert
+		{
+			name:  "ZITADEL_DATABASE_POSTGRES_USER_SSL_ROOTCERT"
+			value: "/\(_PGBouncer)/ca.crt"
+		},
+		{
+			name:  "ZITADEL_DATABASE_POSTGRES_ADMIN_SSL_ROOTCERT"
+			value: "/\(_PGBouncer)/ca.crt"
+		},
 	]
 
 	// Refer to https://zitadel.com/docs/self-hosting/manage/database
 	zitadel: {
 		// Zitadel master key
 		masterkeySecretName: "zitadel-masterkey"
-		// Note the tls configuration is a challenge to use externally issued certs from the provsioner cluster.
-		// We intentionally use pgo managed certs and intend to backup the ca key to the provisioner and restore it for
-		// cross cluster replication.  The problems seemed to arise from specifying the user and admin tls secrets in
-		// addition to the ca cert secret.
-		dbSslCaCrtSecret: "\(_DBName)-cluster-cert"
+		// dbSslCaCrtSecret: "pgo-root-cacert"
 
 		// All settings: https://zitadel.com/docs/self-hosting/manage/configure#runtime-configuration-file
 		// Helm interface: https://github.com/zitadel/zitadel-charts/blob/zitadel-7.4.0/charts/zitadel/values.yaml#L20-L21

--- a/docs/examples/schema.cue
+++ b/docs/examples/schema.cue
@@ -82,6 +82,7 @@ _apiVersion: "holos.run/v1alpha1"
 }
 
 #NamespaceObject: #ClusterObject & {
+	metadata: name:      string
 	metadata: namespace: string
 	...
 }
@@ -304,6 +305,7 @@ _apiVersion: "holos.run/v1alpha1"
 		}
 		ExternalSecret?: [Name=_]: #ExternalSecret & {_name: Name}
 		VirtualService?: [Name=_]: #VirtualService & {metadata: name: Name}
+		Issuer?: [Name=_]: #Issuer & {metadata: name: Name}
 	}
 
 	// apiObjectMap holds the marshalled representation of apiObjects
@@ -458,6 +460,12 @@ _apiVersion: "holos.run/v1alpha1"
 		seccompProfile: type: "RuntimeDefault"
 	}
 	...
+}
+
+// Certificate name should always match the secret name.
+#Certificate: {
+	metadata: name:   _
+	spec: secretName: metadata.name
 }
 
 // By default, render kind: Skipped so holos knows to skip over intermediate cue files.


### PR DESCRIPTION
The [Streaming Standby][standby] architecture requires custom tls certs for two clusters in two regions to connect to each other.

This patch manages the custom certs following the configuration described in the article [Using Cert Manager to Deploy TLS for Postgres on Kubernetes][article].

> [!NOTE]
> The pgbouncer service uses a tls certificate issued by the pgo root cert, not by the custom certificate authority.  This is not mentioned in any of the crunchy custom tls documentation.

For this reason, we use kustomize to patch the zitadel Deployment and the zitadel-init and zitadel-setup Jobs.  The patch projects the ca bundle from the `zitadel-pgbouncer` secret into the zitadel pods at /pgbouncer/ca.crt

<details><summary>pgbouncer-frontend.crt</summary>

```console
kubectl get secret zitadel-pgbouncer -o json | jq --exit-status -r '.data | map_values(@base64d) | ."pgbouncer-frontend.crt"' | openssl x509 -noout -text -in -
```

```txt
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number:
            f0:8f:ca:4b:74:fe:ff:e5:a7:1a:fe:0f:18:71:4d:af
        Signature Algorithm: ecdsa-with-SHA384
        Issuer: CN = postgres-operator-ca
        Validity
            Not Before: Mar 11 04:02:45 2024 GMT
            Not After : Mar 11 05:02:45 2025 GMT
        Subject: CN = zitadel-pgbouncer.prod-iam-zitadel.svc.cluster.local.
        Subject Public Key Info:
            Public Key Algorithm: id-ecPublicKey
                Public-Key: (256 bit)
                pub:
                    04:b0:22:39:bb:1c:ce:83:5e:29:df:8d:bd:eb:fd:
                    8e:b9:b3:bd:f3:fb:b3:d4:44:d3:73:a7:7f:e3:bd:
                    eb:6e:c3:b7:50:d1:25:47:a4:8d:09:20:8a:f5:a0:
                    83:5e:57:a0:e3:64:e7:62:13:a0:a5:49:75:2b:b5:
                    b8:a1:ea:36:b7
                ASN1 OID: prime256v1
                NIST CURVE: P-256
        X509v3 extensions:
            X509v3 Key Usage: critical
                Digital Signature, Key Encipherment
            X509v3 Basic Constraints: critical
                CA:FALSE
            X509v3 Authority Key Identifier:
                keyid:46:17:C9:A9:10:A0:49:A9:C2:0A:AF:91:40:67:30:21:ED:72:BF:A1

            X509v3 Subject Alternative Name:
                DNS:zitadel-pgbouncer.prod-iam-zitadel.svc.cluster.local., DNS:zitadel-pgbouncer.prod-iam-zitadel.svc, DNS:zitadel-pgbouncer.prod-iam-zitadel, DNS:zitadel-pgbouncer
    Signature Algorithm: ecdsa-with-SHA384
         30:46:02:21:00:fa:57:e9:87:aa:f0:bd:1e:32:a7:5a:16:b3:
         85:d0:59:69:b4:40:ad:79:f4:a2:89:d4:6b:d3:2b:d0:54:e8:
         4e:02:21:00:9b:b3:90:97:00:f7:43:a6:90:dd:e4:14:ea:8f:
         7b:bd:88:52:b6:02:26:a3:e4:bf:6c:f1:2f:12:62:ec:b7:0d
```

</details>

[standby]: https://access.crunchydata.com/documentation/postgres-operator/latest/architecture/disaster-recovery#streaming-standby-with-an-external-repo
[article]: https://www.crunchydata.com/blog/using-cert-manager-to-deploy-tls-for-postgres-on-kubernetes
