### PR TITLE
(#96) Do not expire ZITADEL signing private key

### DIFF
--- a/docs/examples/platforms/reference/clusters/accounts/iam/zitadel/zitadel/values.holos.cue
+++ b/docs/examples/platforms/reference/clusters/accounts/iam/zitadel/zitadel/values.holos.cue
@@ -74,6 +74,11 @@ package holos
 			ExternalPort:   443
 			TLS: Enabled: false
 
+			// Fix AuthProxy JWKS Error - Jwks doesn't have key to match kid or alg from Jwt
+			// Refer to: https://github.com/holos-run/holos/issues/96
+			// Refer to: https://github.com/zitadel/zitadel/discussions/7464
+			SystemDefaults: KeyConfig: PrivateKeyLifetime: "999999h"
+
 			// Database connection credentials are injected via environment variables from the db-pguser-db secret.
 			Database: postgres: {
 				MaxOpenConns:    25


### PR DESCRIPTION
Without this patch users encounter an error from istio because it does
not have a valid Jwks from ZITADEL to verify the request when processing
a `RequestAuthentication` policy.

Fixes error `AuthProxy JWKS Error - Jwks doesn't have key to match kid or alg from Jwt`.

Occurs when accessing a protected URL for the first time after tokens have expired.


Closes: #96
