### PR TITLE
(#137) Fix ArgoCD PKCE login

### DIFF
--- a/docs/examples/platforms/reference/clusters/foundation/cloud/argocd/argocd.cue
+++ b/docs/examples/platforms/reference/clusters/foundation/cloud/argocd/argocd.cue
@@ -71,14 +71,14 @@ let IstioInject = [{op: "add", path: "/spec/template/metadata/labels/sidecar.ist
 	}
 }
 
-// Probably shouldn't use the authproxy struct and should instead define an identity provider struct.
-let AuthProxySpec = #AuthProxySpec & #Platform.authproxy
+let OAuthClient = #Platform.oauthClients.argocd.spec
 
 let OIDCConfig = {
-	name:     "Holos Platform"
-	issuer:   AuthProxySpec.issuer
-	clientID: #Platform.argocd.clientID
-	requestedIDTokenClaims: groups: essential: true
-	requestedScopes: ["openid", "profile", "email", "groups", "urn:zitadel:iam:org:domain:primary:\(AuthProxySpec.orgDomain)"]
+	name:                     "Holos Platform"
+	issuer:                   OAuthClient.issuer
+	clientID:                 OAuthClient.clientID
+	requestedScopes:          OAuthClient.scopesList
 	enablePKCEAuthentication: true
+
+	requestedIDTokenClaims: groups: essential: true
 }


### PR DESCRIPTION
This patch configures ArgoCD to log in via PKCE.

Note the changes are primarily in platform.site.cue and ensuring the
emailDomain is set properly.  Note too the redirect URL needs to be
`/pkce/verify` when PKCE is enabled.  Finally, if the setting is
reconfigured make sure to clear cookies otherwise the incorrect
`/auth/callback` path may be used.


Closes: #137
