### PR TITLE
(#146) Platform Config Mock Up

### DIFF
--- a/internal/frontend/holos/package-lock.json
+++ b/internal/frontend/holos/package-lock.json
@@ -22,6 +22,8 @@
         "@connectrpc/connect": "^1.4.0",
         "@connectrpc/connect-query": "^1.3.1",
         "@connectrpc/connect-web": "^1.4.0",
+        "@ngx-formly/core": "^6.3.0",
+        "@ngx-formly/material": "^6.3.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.3"
@@ -34,6 +36,7 @@
         "@bufbuild/protoc-gen-es": "^1.9.0",
         "@connectrpc/protoc-gen-connect-es": "^1.4.0",
         "@connectrpc/protoc-gen-connect-query": "^1.3.1",
+        "@ngx-formly/schematics": "^6.3.0",
         "@types/jasmine": "~5.1.0",
         "jasmine-core": "~5.1.0",
         "karma": "~6.4.0",
@@ -3942,6 +3945,160 @@
         "typescript": ">=5.2 <5.5",
         "webpack": "^5.54.0"
       }
+    },
+    "node_modules/@ngx-formly/core": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@ngx-formly/core/-/core-6.3.0.tgz",
+      "integrity": "sha512-9qCoPdLLVShoruzXeJUjMdIhfIlHCI+TggA3Wc01ISHTK2vXx1gNIFLuS+hez3JEzu8nIDRuA/nWqj4j8fJCNg==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/forms": ">=13.2.0",
+        "rxjs": "^6.5.3 || ^7.0.0"
+      }
+    },
+    "node_modules/@ngx-formly/material": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@ngx-formly/material/-/material-6.3.0.tgz",
+      "integrity": "sha512-kzNNXQhOtPf2Uc4l02CO7njwKNJsaP+dpLt6cvYQA04fVALrO/dEJNbgUW6rlVp0oQQmobiu83lN1qWKmqAcng==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/material": ">=13.0.0",
+        "@ngx-formly/core": "6.3.0"
+      }
+    },
+    "node_modules/@ngx-formly/schematics": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@ngx-formly/schematics/-/schematics-6.3.0.tgz",
+      "integrity": "sha512-XSzOvrZ1NoUhmd733bcgUFkl+26pSw8eyXChi9LwrS26nEPweR8RA/JxN+lFvIb92MWzLShLd1DY2oBz/0r0ZQ==",
+      "dev": true,
+      "dependencies": {
+        "@angular-devkit/core": "^13.0.3",
+        "@angular-devkit/schematics": "^13.0.3",
+        "@schematics/angular": "^13.0.3"
+      }
+    },
+    "node_modules/@ngx-formly/schematics/node_modules/@angular-devkit/core": {
+      "version": "13.3.11",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-13.3.11.tgz",
+      "integrity": "sha512-rfqoLMRYhlz0wzKlHx7FfyIyQq8dKTsmbCoIVU1cEIH0gyTMVY7PbVzwRRcO6xp5waY+0hA+0Brriujpuhkm4w==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "8.9.0",
+        "ajv-formats": "2.1.1",
+        "fast-json-stable-stringify": "2.1.0",
+        "magic-string": "0.25.7",
+        "rxjs": "6.6.7",
+        "source-map": "0.7.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.15.0 || >=16.10.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^3.5.2"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ngx-formly/schematics/node_modules/@angular-devkit/schematics": {
+      "version": "13.3.11",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-13.3.11.tgz",
+      "integrity": "sha512-ben+EGXpCrClnIVAAnEQmhQdKmnnqFhMp5BqMxgOslSYBAmCutLA6rBu5vsc8kZcGian1wt+lueF7G1Uk5cGBg==",
+      "dev": true,
+      "dependencies": {
+        "@angular-devkit/core": "13.3.11",
+        "jsonc-parser": "3.0.0",
+        "magic-string": "0.25.7",
+        "ora": "5.4.1",
+        "rxjs": "6.6.7"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.15.0 || >=16.10.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@ngx-formly/schematics/node_modules/@schematics/angular": {
+      "version": "13.3.11",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-13.3.11.tgz",
+      "integrity": "sha512-imKBnKYEse0SBVELZO/753nkpt3eEgpjrYkB+AFWF9YfO/4RGnYXDHoH8CFkzxPH9QQCgNrmsVFNiYGS+P/S1A==",
+      "dev": true,
+      "dependencies": {
+        "@angular-devkit/core": "13.3.11",
+        "@angular-devkit/schematics": "13.3.11",
+        "jsonc-parser": "3.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.15.0 || >=16.10.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@ngx-formly/schematics/node_modules/ajv": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
+      "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@ngx-formly/schematics/node_modules/jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
+    },
+    "node_modules/@ngx-formly/schematics/node_modules/magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.4"
+      }
+    },
+    "node_modules/@ngx-formly/schematics/node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/@ngx-formly/schematics/node_modules/source-map": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@ngx-formly/schematics/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -11873,6 +12030,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true
     },
     "node_modules/spdx-correct": {
       "version": "3.2.0",

--- a/internal/frontend/holos/package.json
+++ b/internal/frontend/holos/package.json
@@ -24,6 +24,8 @@
     "@connectrpc/connect": "^1.4.0",
     "@connectrpc/connect-query": "^1.3.1",
     "@connectrpc/connect-web": "^1.4.0",
+    "@ngx-formly/core": "^6.3.0",
+    "@ngx-formly/material": "^6.3.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.3"
@@ -36,6 +38,7 @@
     "@bufbuild/protoc-gen-es": "^1.9.0",
     "@connectrpc/protoc-gen-connect-es": "^1.4.0",
     "@connectrpc/protoc-gen-connect-query": "^1.3.1",
+    "@ngx-formly/schematics": "^6.3.0",
     "@types/jasmine": "~5.1.0",
     "jasmine-core": "~5.1.0",
     "karma": "~6.4.0",

--- a/internal/frontend/holos/src/app/app.config.ts
+++ b/internal/frontend/holos/src/app/app.config.ts
@@ -1,7 +1,7 @@
 import { ApplicationConfig, importProvidersFrom } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { FormlyModule } from '@ngx-formly/core';
 // import { provideHttpClient, withFetch } from '@angular/common/http';
-
 import { routes } from './app.routes';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { ConnectModule } from '../connect/connect.module';
@@ -20,6 +20,7 @@ export const appConfig: ApplicationConfig = {
       ConnectModule.forRoot({
         baseUrl: window.location.origin
       }),
+      FormlyModule.forRoot(),
     ),
   ]
 };

--- a/internal/frontend/holos/src/app/app.routes.ts
+++ b/internal/frontend/holos/src/app/app.routes.ts
@@ -2,8 +2,12 @@ import { Routes } from '@angular/router';
 import { HomeComponent } from './home/home.component';
 import { ClusterListComponent } from './cluster-list/cluster-list.component';
 import { ErrorNotFoundComponent } from './error-not-found/error-not-found.component';
+import { PlatformConfigComponent } from './views/platform-config/platform-config.component';
+import { AddressFormComponent } from './examples/address-form/address-form.component';
 
 export const routes: Routes = [
+  { path: 'platform-config', component: PlatformConfigComponent },
+  { path: 'address-form', component: AddressFormComponent },
   { path: 'home', component: HomeComponent },
   { path: 'clusters', component: ClusterListComponent },
   { path: '', redirectTo: '/home', pathMatch: 'full' },

--- a/internal/frontend/holos/src/app/examples/address-form/address-form.component.html
+++ b/internal/frontend/holos/src/app/examples/address-form/address-form.component.html
@@ -1,0 +1,99 @@
+<form [formGroup]="addressForm" novalidate (ngSubmit)="onSubmit()">
+  <mat-card class="shipping-card">
+    <mat-card-header>
+      <mat-card-title>Shipping Information</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <div class="row">
+        <div class="col">
+          <mat-form-field class="full-width">
+            <input matInput placeholder="Company" formControlName="company">
+          </mat-form-field>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col">
+          <mat-form-field class="full-width">
+            <input matInput placeholder="First name" formControlName="firstName">
+            @if (addressForm.controls['firstName'].hasError('required')) {
+              <mat-error>First name is <strong>required</strong></mat-error>
+            }
+          </mat-form-field>
+        </div>
+        <div class="col">
+          <mat-form-field class="full-width">
+            <input matInput placeholder="Last name" formControlName="lastName">
+            @if (addressForm.controls['lastName'].hasError('required')) {
+              <mat-error>Last name is <strong>required</strong></mat-error>
+            }
+          </mat-form-field>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col">
+          <mat-form-field class="full-width">
+            <textarea matInput placeholder="Address" formControlName="address"></textarea>
+            @if (addressForm.controls['address'].hasError('required')) {
+              <mat-error>Address is <strong>required</strong></mat-error>
+            }
+          </mat-form-field>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col">
+          @if (hasUnitNumber) {
+            <mat-form-field class="full-width">
+              <textarea matInput placeholder="Address 2" formControlName="address2"></textarea>
+            </mat-form-field>
+          } @else {
+            <button mat-button type="button" (click)="hasUnitNumber = !hasUnitNumber">
+              + Add C/O, Apt, Suite, Unit
+            </button>
+          }
+        </div>
+      </div>
+      <div class="row">
+        <div class="col">
+          <mat-form-field class="full-width">
+            <input matInput placeholder="City" formControlName="city">
+            @if (addressForm.controls['city'].hasError('required')) {
+              <mat-error>City is <strong>required</strong></mat-error>
+            }
+          </mat-form-field>
+        </div>
+        <div class="col">
+          <mat-form-field class="full-width">
+            <mat-select placeholder="State" formControlName="state">
+              @for (state of states; track state) {
+                <mat-option [value]="state.abbreviation">{{ state.name }}</mat-option>
+              }
+            </mat-select>
+            @if (addressForm.controls['state'].hasError('required')) {
+              <mat-error>State is <strong>required</strong></mat-error>
+            }
+          </mat-form-field>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col">
+          <mat-form-field class="full-width">
+            <input matInput #postalCode maxlength="5" placeholder="Postal Code" type="number" formControlName="postalCode">
+            <mat-hint align="end">{{postalCode.value.length}} / 5</mat-hint>
+          </mat-form-field>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col">
+          <mat-radio-group formControlName="shipping">
+            <mat-radio-button value="free">Free Shipping</mat-radio-button>
+            <mat-radio-button value="priority">Priority Shipping</mat-radio-button>
+            <mat-radio-button value="nextday">Next Day Shipping</mat-radio-button>
+          </mat-radio-group>
+        </div>
+      </div>
+    </mat-card-content>
+    <mat-card-actions>
+      <button mat-raised-button color="primary" type="submit">Submit</button>
+    </mat-card-actions>
+  </mat-card>
+</form>

--- a/internal/frontend/holos/src/app/examples/address-form/address-form.component.scss
+++ b/internal/frontend/holos/src/app/examples/address-form/address-form.component.scss
@@ -1,0 +1,27 @@
+.full-width {
+  width: 100%;
+}
+
+.shipping-card {
+  min-width: 120px;
+  margin: 20px auto;
+}
+
+.mat-radio-button {
+  display: block;
+  margin: 5px 0;
+}
+
+.row {
+  display: flex;
+  flex-direction: row;
+}
+
+.col {
+  flex: 1;
+  margin-right: 20px;
+}
+
+.col:last-child {
+  margin-right: 0;
+}

--- a/internal/frontend/holos/src/app/examples/address-form/address-form.component.spec.ts
+++ b/internal/frontend/holos/src/app/examples/address-form/address-form.component.spec.ts
@@ -1,0 +1,25 @@
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { AddressFormComponent } from './address-form.component';
+
+describe('AddressFormComponent', () => {
+  let component: AddressFormComponent;
+  let fixture: ComponentFixture<AddressFormComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AddressFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should compile', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/internal/frontend/holos/src/app/examples/address-form/address-form.component.ts
+++ b/internal/frontend/holos/src/app/examples/address-form/address-form.component.ts
@@ -1,0 +1,108 @@
+import { Component, inject } from '@angular/core';
+
+import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatSelectModule } from '@angular/material/select';
+import { MatRadioModule } from '@angular/material/radio';
+import { MatCardModule } from '@angular/material/card';
+
+
+@Component({
+  selector: 'app-address-form',
+  templateUrl: './address-form.component.html',
+  styleUrl: './address-form.component.scss',
+  standalone: true,
+  imports: [
+    MatInputModule,
+    MatButtonModule,
+    MatSelectModule,
+    MatRadioModule,
+    MatCardModule,
+    ReactiveFormsModule
+  ]
+})
+export class AddressFormComponent {
+  private fb = inject(FormBuilder);
+  addressForm = this.fb.group({
+    company: null,
+    firstName: [null, Validators.required],
+    lastName: [null, Validators.required],
+    address: [null, Validators.required],
+    address2: null,
+    city: [null, Validators.required],
+    state: [null, Validators.required],
+    postalCode: [null, Validators.compose([
+      Validators.required, Validators.minLength(5), Validators.maxLength(5)])
+    ],
+    shipping: ['free', Validators.required]
+  });
+
+  hasUnitNumber = false;
+
+  states = [
+    {name: 'Alabama', abbreviation: 'AL'},
+    {name: 'Alaska', abbreviation: 'AK'},
+    {name: 'American Samoa', abbreviation: 'AS'},
+    {name: 'Arizona', abbreviation: 'AZ'},
+    {name: 'Arkansas', abbreviation: 'AR'},
+    {name: 'California', abbreviation: 'CA'},
+    {name: 'Colorado', abbreviation: 'CO'},
+    {name: 'Connecticut', abbreviation: 'CT'},
+    {name: 'Delaware', abbreviation: 'DE'},
+    {name: 'District Of Columbia', abbreviation: 'DC'},
+    {name: 'Federated States Of Micronesia', abbreviation: 'FM'},
+    {name: 'Florida', abbreviation: 'FL'},
+    {name: 'Georgia', abbreviation: 'GA'},
+    {name: 'Guam', abbreviation: 'GU'},
+    {name: 'Hawaii', abbreviation: 'HI'},
+    {name: 'Idaho', abbreviation: 'ID'},
+    {name: 'Illinois', abbreviation: 'IL'},
+    {name: 'Indiana', abbreviation: 'IN'},
+    {name: 'Iowa', abbreviation: 'IA'},
+    {name: 'Kansas', abbreviation: 'KS'},
+    {name: 'Kentucky', abbreviation: 'KY'},
+    {name: 'Louisiana', abbreviation: 'LA'},
+    {name: 'Maine', abbreviation: 'ME'},
+    {name: 'Marshall Islands', abbreviation: 'MH'},
+    {name: 'Maryland', abbreviation: 'MD'},
+    {name: 'Massachusetts', abbreviation: 'MA'},
+    {name: 'Michigan', abbreviation: 'MI'},
+    {name: 'Minnesota', abbreviation: 'MN'},
+    {name: 'Mississippi', abbreviation: 'MS'},
+    {name: 'Missouri', abbreviation: 'MO'},
+    {name: 'Montana', abbreviation: 'MT'},
+    {name: 'Nebraska', abbreviation: 'NE'},
+    {name: 'Nevada', abbreviation: 'NV'},
+    {name: 'New Hampshire', abbreviation: 'NH'},
+    {name: 'New Jersey', abbreviation: 'NJ'},
+    {name: 'New Mexico', abbreviation: 'NM'},
+    {name: 'New York', abbreviation: 'NY'},
+    {name: 'North Carolina', abbreviation: 'NC'},
+    {name: 'North Dakota', abbreviation: 'ND'},
+    {name: 'Northern Mariana Islands', abbreviation: 'MP'},
+    {name: 'Ohio', abbreviation: 'OH'},
+    {name: 'Oklahoma', abbreviation: 'OK'},
+    {name: 'Oregon', abbreviation: 'OR'},
+    {name: 'Palau', abbreviation: 'PW'},
+    {name: 'Pennsylvania', abbreviation: 'PA'},
+    {name: 'Puerto Rico', abbreviation: 'PR'},
+    {name: 'Rhode Island', abbreviation: 'RI'},
+    {name: 'South Carolina', abbreviation: 'SC'},
+    {name: 'South Dakota', abbreviation: 'SD'},
+    {name: 'Tennessee', abbreviation: 'TN'},
+    {name: 'Texas', abbreviation: 'TX'},
+    {name: 'Utah', abbreviation: 'UT'},
+    {name: 'Vermont', abbreviation: 'VT'},
+    {name: 'Virgin Islands', abbreviation: 'VI'},
+    {name: 'Virginia', abbreviation: 'VA'},
+    {name: 'Washington', abbreviation: 'WA'},
+    {name: 'West Virginia', abbreviation: 'WV'},
+    {name: 'Wisconsin', abbreviation: 'WI'},
+    {name: 'Wyoming', abbreviation: 'WY'}
+  ];
+
+  onSubmit(): void {
+    alert('Thanks!');
+  }
+}

--- a/internal/frontend/holos/src/app/nav/nav.component.html
+++ b/internal/frontend/holos/src/app/nav/nav.component.html
@@ -7,8 +7,10 @@
       <span>Menu</span>
     </mat-toolbar>
     <mat-nav-list>
+      <a mat-list-item routerLink="/platform-config" routerLinkActive="active-link">Platform Config</a>
       <a mat-list-item routerLink="/home" routerLinkActive="active-link">Home</a>
       <a mat-list-item routerLink="/clusters" routerLinkActive="active-link">Clusters</a>
+      <a mat-list-item routerLink="/address-form" routerLinkActive="active-link">Address Form</a>
     </mat-nav-list>
   </mat-sidenav>
   <mat-sidenav-content>

--- a/internal/frontend/holos/src/app/views/platform-config/platform-config.component.html
+++ b/internal/frontend/holos/src/app/views/platform-config/platform-config.component.html
@@ -1,0 +1,56 @@
+<mat-tab-group>
+  <mat-tab label="Organization">
+    <form [formGroup]="form" (ngSubmit)="onSubmit(model)">
+      <mat-card class="config-card">
+        <mat-card-header>
+          <mat-card-title>Organization</mat-card-title>
+        </mat-card-header>
+        <mat-card-content>
+          <p>Organization config values are used to derive more specific configuration values throughout the platform.</p>
+          <formly-form [form]="form" [fields]="fields" [model]="model">
+          </formly-form>
+        </mat-card-content>
+        <mat-card-actions>
+          <button mat-raised-button color="primary" type="submit">Submit</button>
+        </mat-card-actions>
+      </mat-card>
+    </form>
+
+  </mat-tab>
+  <mat-tab label="Integrations">
+    <form [formGroup]="form" (ngSubmit)="onSubmit(model)">
+      <mat-card class="config-card">
+        <mat-card-header>
+          <mat-card-title>Integrations</mat-card-title>
+        </mat-card-header>
+        <mat-card-content>
+          <p>Configure integrations with your DNS and version control service providers.</p>
+          <formly-form [form]="form" [fields]="integrationFields" [model]="model">
+          </formly-form>
+        </mat-card-content>
+        <mat-card-actions>
+          <button mat-raised-button color="primary" type="submit">Submit</button>
+        </mat-card-actions>
+      </mat-card>
+    </form>
+
+  </mat-tab>
+  <mat-tab label="Provisioner">
+    <form [formGroup]="form" (ngSubmit)="onSubmit(model)">
+      <mat-card class="config-card">
+        <mat-card-header>
+          <mat-card-title>Provisioner Cluster</mat-card-title>
+        </mat-card-header>
+        <mat-card-content>
+          <p>Provide the connection details used to sync secrets among platform clusters.</p>
+          <formly-form [form]="form" [fields]="provisionerFields" [model]="model">
+          </formly-form>
+        </mat-card-content>
+        <mat-card-actions>
+          <button mat-raised-button color="primary" type="submit">Submit</button>
+        </mat-card-actions>
+      </mat-card>
+    </form>
+  </mat-tab>
+  <mat-tab label="OAuth Clients"></mat-tab>
+</mat-tab-group>

--- a/internal/frontend/holos/src/app/views/platform-config/platform-config.component.scss
+++ b/internal/frontend/holos/src/app/views/platform-config/platform-config.component.scss
@@ -1,0 +1,27 @@
+.full-width {
+  width: 100%;
+}
+
+.config-card {
+  min-width: 120px;
+  margin: 20px auto;
+}
+
+.mat-radio-button {
+  display: block;
+  margin: 5px 0;
+}
+
+.row {
+  display: flex;
+  flex-direction: row;
+}
+
+.col {
+  flex: 1;
+  margin-right: 20px;
+}
+
+.col:last-child {
+  margin-right: 0;
+}

--- a/internal/frontend/holos/src/app/views/platform-config/platform-config.component.spec.ts
+++ b/internal/frontend/holos/src/app/views/platform-config/platform-config.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PlatformConfigComponent } from './platform-config.component';
+
+describe('PlatformConfigComponent', () => {
+  let component: PlatformConfigComponent;
+  let fixture: ComponentFixture<PlatformConfigComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PlatformConfigComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(PlatformConfigComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/internal/frontend/holos/src/app/views/platform-config/platform-config.component.ts
+++ b/internal/frontend/holos/src/app/views/platform-config/platform-config.component.ts
@@ -1,0 +1,122 @@
+import { Component } from '@angular/core';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MatButton } from '@angular/material/button';
+import { MatCard, MatCardActions, MatCardContent, MatCardHeader, MatCardTitle } from '@angular/material/card';
+import { FormlyModule, FormlyFieldConfig } from '@ngx-formly/core';
+import { FormlyMaterialModule } from '@ngx-formly/material';
+
+@Component({
+  selector: 'app-platform-config',
+  standalone: true,
+  imports: [
+    ReactiveFormsModule,
+    FormlyMaterialModule,
+    FormlyModule,
+    MatTabsModule,
+    MatCard,
+    MatCardHeader,
+    MatCardTitle,
+    MatCardContent,
+    MatCardActions,
+    MatButton,
+  ],
+  templateUrl: './platform-config.component.html',
+  styleUrl: './platform-config.component.scss'
+})
+export class PlatformConfigComponent {
+  form = new FormGroup({});
+  model: any = {};
+  fields: FormlyFieldConfig[] = [
+    {
+      key: 'name',
+      type: 'input',
+      props: {
+        label: 'Name',
+        placeholder: 'example',
+        required: true,
+        description: "DNS label, e.g. 'example'"
+      }
+    },
+    {
+      key: 'domain',
+      type: 'input',
+      props: {
+        label: 'Domain',
+        placeholder: 'example.com',
+        required: true,
+        description: "DNS domain, e.g. 'example.com'"
+      }
+    },
+    {
+      key: 'displayName',
+      type: 'input',
+      props: {
+        label: 'Display Name',
+        placeholder: 'Example Organization',
+        required: true,
+        description: "Display name, e.g. 'My Organization'"
+      }
+    },
+    {
+      key: 'contactEmail',
+      type: 'input',
+      props: {
+        label: 'Contact Email',
+        placeholder: '',
+        required: true,
+        description: "Organization technical contact."
+      }
+    },
+  ];
+
+  integrationFields: FormlyFieldConfig[] = [
+    {
+      key: 'cloudflareEmail',
+      type: 'input',
+      props: {
+        label: 'Cloudflare Account',
+        placeholder: 'example@example.com',
+        required: true,
+        description: "Cloudflare account email address."
+      }
+    },
+    {
+      key: 'githubPrimaryOrg',
+      type: 'input',
+      props: {
+        label: 'Github Organization',
+        placeholder: 'ExampleOrg',
+        required: true,
+        description: "Github organization, e.g. 'ExampleOrg'"
+      }
+    }
+  ];
+
+  provisionerFields: FormlyFieldConfig[] = [
+    {
+      key: 'provisionerCABundle',
+      type: 'input',
+      props: {
+        label: 'Provisioner API CA Bundle',
+        placeholder: 'LS0tLS1CRUdJTiBDRVJUSUZJQXXXXXXXXXXXXXXXXXXXXXXX',
+        required: true,
+        description: "kubectl config view --minify --flatten -ojsonpath='{.clusters[0].cluster.certificate-authority-data}'"
+      }
+    },
+    {
+      key: 'provisionerURL',
+      type: 'input',
+      props: {
+        label: 'Provisioner API URL',
+        placeholder: 'https://1.2.3.4',
+        required: true,
+        description: "kubectl config view --minify --flatten -ojsonpath='{.clusters[0].cluster.server}'"
+      }
+    }
+  ]
+
+  onSubmit(model: any) {
+    console.log(model);
+  }
+}


### PR DESCRIPTION
This patch adds a mock up of the platform config.  The goal is to use
this to connect to an anemic example platform built from `holos init`.


Closes: #146
