### PR TITLE
(#150) Refactor PlatformService.GetConfig for use with CUE

### DIFF
--- a/internal/ent/mutation.go
+++ b/internal/ent/mutation.go
@@ -814,7 +814,7 @@ type PlatformMutation struct {
 	name                *string
 	display_name        *string
 	config_form         **holos.PlatformForm
-	config_values       **holos.ConfigValues
+	config_values       **holos.UserDefinedConfig
 	config_cue          *[]byte
 	config_definition   *string
 	clearedFields       map[string]struct{}
@@ -1197,12 +1197,12 @@ func (m *PlatformMutation) ResetConfigForm() {
 }
 
 // SetConfigValues sets the "config_values" field.
-func (m *PlatformMutation) SetConfigValues(hv *holos.ConfigValues) {
-	m.config_values = &hv
+func (m *PlatformMutation) SetConfigValues(hdc *holos.UserDefinedConfig) {
+	m.config_values = &hdc
 }
 
 // ConfigValues returns the value of the "config_values" field in the mutation.
-func (m *PlatformMutation) ConfigValues() (r *holos.ConfigValues, exists bool) {
+func (m *PlatformMutation) ConfigValues() (r *holos.UserDefinedConfig, exists bool) {
 	v := m.config_values
 	if v == nil {
 		return
@@ -1213,7 +1213,7 @@ func (m *PlatformMutation) ConfigValues() (r *holos.ConfigValues, exists bool) {
 // OldConfigValues returns the old "config_values" field's value of the Platform entity.
 // If the Platform object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *PlatformMutation) OldConfigValues(ctx context.Context) (v *holos.ConfigValues, err error) {
+func (m *PlatformMutation) OldConfigValues(ctx context.Context) (v *holos.UserDefinedConfig, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, errors.New("OldConfigValues is only allowed on UpdateOne operations")
 	}
@@ -1591,7 +1591,7 @@ func (m *PlatformMutation) SetField(name string, value ent.Value) error {
 		m.SetConfigForm(v)
 		return nil
 	case platform.FieldConfigValues:
-		v, ok := value.(*holos.ConfigValues)
+		v, ok := value.(*holos.UserDefinedConfig)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}

--- a/internal/ent/platform.go
+++ b/internal/ent/platform.go
@@ -37,7 +37,7 @@ type Platform struct {
 	// JSON holos.PlatformForm representing the platform data entry form.
 	ConfigForm *holos.PlatformForm `json:"config_form,omitempty"`
 	// JSON holos.ConfigValues representing the platform config values.
-	ConfigValues *holos.ConfigValues `json:"config_values,omitempty"`
+	ConfigValues *holos.UserDefinedConfig `json:"config_values,omitempty"`
 	// Opaque bytes representing the CUE definition of the config struct.
 	ConfigCue []byte `json:"config_cue,omitempty"`
 	// The definition name to vet config_values against config_cue e.g. '#PlatformSpec'

--- a/internal/ent/platform_create.go
+++ b/internal/ent/platform_create.go
@@ -86,8 +86,8 @@ func (pc *PlatformCreate) SetConfigForm(hf *holos.PlatformForm) *PlatformCreate 
 }
 
 // SetConfigValues sets the "config_values" field.
-func (pc *PlatformCreate) SetConfigValues(hv *holos.ConfigValues) *PlatformCreate {
-	pc.mutation.SetConfigValues(hv)
+func (pc *PlatformCreate) SetConfigValues(hdc *holos.UserDefinedConfig) *PlatformCreate {
+	pc.mutation.SetConfigValues(hdc)
 	return pc
 }
 
@@ -454,7 +454,7 @@ func (u *PlatformUpsert) ClearConfigForm() *PlatformUpsert {
 }
 
 // SetConfigValues sets the "config_values" field.
-func (u *PlatformUpsert) SetConfigValues(v *holos.ConfigValues) *PlatformUpsert {
+func (u *PlatformUpsert) SetConfigValues(v *holos.UserDefinedConfig) *PlatformUpsert {
 	u.Set(platform.FieldConfigValues, v)
 	return u
 }
@@ -650,7 +650,7 @@ func (u *PlatformUpsertOne) ClearConfigForm() *PlatformUpsertOne {
 }
 
 // SetConfigValues sets the "config_values" field.
-func (u *PlatformUpsertOne) SetConfigValues(v *holos.ConfigValues) *PlatformUpsertOne {
+func (u *PlatformUpsertOne) SetConfigValues(v *holos.UserDefinedConfig) *PlatformUpsertOne {
 	return u.Update(func(s *PlatformUpsert) {
 		s.SetConfigValues(v)
 	})
@@ -1022,7 +1022,7 @@ func (u *PlatformUpsertBulk) ClearConfigForm() *PlatformUpsertBulk {
 }
 
 // SetConfigValues sets the "config_values" field.
-func (u *PlatformUpsertBulk) SetConfigValues(v *holos.ConfigValues) *PlatformUpsertBulk {
+func (u *PlatformUpsertBulk) SetConfigValues(v *holos.UserDefinedConfig) *PlatformUpsertBulk {
 	return u.Update(func(s *PlatformUpsert) {
 		s.SetConfigValues(v)
 	})

--- a/internal/ent/platform_update.go
+++ b/internal/ent/platform_update.go
@@ -107,8 +107,8 @@ func (pu *PlatformUpdate) ClearConfigForm() *PlatformUpdate {
 }
 
 // SetConfigValues sets the "config_values" field.
-func (pu *PlatformUpdate) SetConfigValues(hv *holos.ConfigValues) *PlatformUpdate {
-	pu.mutation.SetConfigValues(hv)
+func (pu *PlatformUpdate) SetConfigValues(hdc *holos.UserDefinedConfig) *PlatformUpdate {
+	pu.mutation.SetConfigValues(hdc)
 	return pu
 }
 
@@ -433,8 +433,8 @@ func (puo *PlatformUpdateOne) ClearConfigForm() *PlatformUpdateOne {
 }
 
 // SetConfigValues sets the "config_values" field.
-func (puo *PlatformUpdateOne) SetConfigValues(hv *holos.ConfigValues) *PlatformUpdateOne {
-	puo.mutation.SetConfigValues(hv)
+func (puo *PlatformUpdateOne) SetConfigValues(hdc *holos.UserDefinedConfig) *PlatformUpdateOne {
+	puo.mutation.SetConfigValues(hdc)
 	return puo
 }
 

--- a/internal/ent/schema/platform.go
+++ b/internal/ent/schema/platform.go
@@ -29,7 +29,7 @@ func (Platform) Fields() []ent.Field {
 		field.JSON("config_form", &holos.PlatformForm{}).
 			Optional().
 			Comment("JSON holos.PlatformForm representing the platform data entry form."),
-		field.JSON("config_values", &holos.ConfigValues{}).
+		field.JSON("config_values", &holos.UserDefinedConfig{}).
 			Optional().
 			Comment("JSON holos.ConfigValues representing the platform config values."),
 		field.Bytes("config_cue").

--- a/internal/frontend/holos/src/app/gen/holos/v1alpha1/platform-PlatformService_connectquery.ts
+++ b/internal/frontend/holos/src/app/gen/holos/v1alpha1/platform-PlatformService_connectquery.ts
@@ -4,7 +4,7 @@
 // @ts-nocheck
 
 import { MethodKind } from "@bufbuild/protobuf";
-import { AddPlatformRequest, ConfigValues, GetPlatformConfigRequest, GetPlatformRequest, GetPlatformResponse, GetPlatformsRequest, GetPlatformsResponse, PutPlatformConfigRequest } from "./platform_pb.js";
+import { AddPlatformRequest, GetPlatformConfigRequest, GetPlatformRequest, GetPlatformResponse, GetPlatformsRequest, GetPlatformsResponse, PlatformConfig, PutPlatformConfigRequest } from "./platform_pb.js";
 
 /**
  * @generated from rpc holos.v1alpha1.PlatformService.AddPlatform
@@ -72,7 +72,7 @@ export const getConfig = {
   name: "GetConfig",
   kind: MethodKind.Unary,
   I: GetPlatformConfigRequest,
-  O: ConfigValues,
+  O: PlatformConfig,
   service: {
     typeName: "holos.v1alpha1.PlatformService"
   }

--- a/internal/frontend/holos/src/app/gen/holos/v1alpha1/platform_connect.ts
+++ b/internal/frontend/holos/src/app/gen/holos/v1alpha1/platform_connect.ts
@@ -3,7 +3,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { AddPlatformRequest, ConfigValues, GetPlatformConfigRequest, GetPlatformRequest, GetPlatformResponse, GetPlatformsRequest, GetPlatformsResponse, PutPlatformConfigRequest } from "./platform_pb.js";
+import { AddPlatformRequest, GetPlatformConfigRequest, GetPlatformRequest, GetPlatformResponse, GetPlatformsRequest, GetPlatformsResponse, PlatformConfig, PutPlatformConfigRequest } from "./platform_pb.js";
 import { MethodKind } from "@bufbuild/protobuf";
 
 /**
@@ -56,7 +56,7 @@ export const PlatformService = {
     getConfig: {
       name: "GetConfig",
       I: GetPlatformConfigRequest,
-      O: ConfigValues,
+      O: PlatformConfig,
       kind: MethodKind.Unary,
     },
   }

--- a/internal/frontend/holos/src/app/gen/holos/v1alpha1/platform_pb.ts
+++ b/internal/frontend/holos/src/app/gen/holos/v1alpha1/platform_pb.ts
@@ -77,9 +77,9 @@ export class Config extends Message<Config> {
   /**
    * Values are the user supplied config values organized by section.
    *
-   * @generated from field: holos.v1alpha1.ConfigValues values = 2;
+   * @generated from field: holos.v1alpha1.UserDefinedConfig values = 2;
    */
-  values?: ConfigValues;
+  values?: UserDefinedConfig;
 
   constructor(data?: PartialMessage<Config>) {
     super();
@@ -90,7 +90,7 @@ export class Config extends Message<Config> {
   static readonly typeName = "holos.v1alpha1.Config";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "form", kind: "message", T: PlatformForm },
-    { no: 2, name: "values", kind: "message", T: ConfigValues },
+    { no: 2, name: "values", kind: "message", T: UserDefinedConfig },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): Config {
@@ -111,78 +111,231 @@ export class Config extends Message<Config> {
 }
 
 /**
- * @generated from message holos.v1alpha1.ConfigSection
+ * @generated from message holos.v1alpha1.PlatformConfig
  */
-export class ConfigSection extends Message<ConfigSection> {
+export class PlatformConfig extends Message<PlatformConfig> {
+  /**
+   * @generated from field: holos.v1alpha1.PlatformStruct platform = 1;
+   */
+  platform?: PlatformStruct;
+
+  constructor(data?: PartialMessage<PlatformConfig>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "holos.v1alpha1.PlatformConfig";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "platform", kind: "message", T: PlatformStruct },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): PlatformConfig {
+    return new PlatformConfig().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): PlatformConfig {
+    return new PlatformConfig().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): PlatformConfig {
+    return new PlatformConfig().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: PlatformConfig | PlainMessage<PlatformConfig> | undefined, b: PlatformConfig | PlainMessage<PlatformConfig> | undefined): boolean {
+    return proto3.util.equals(PlatformConfig, a, b);
+  }
+}
+
+/**
+ * PlatformConfig represents the platform config struct.  The JSON encoding of this message is directly usable in CUE.
+ * TODO: consolidate PlatformStruct and Platform into one message type representing a Platform resource.
+ *
+ * @generated from message holos.v1alpha1.PlatformStruct
+ */
+export class PlatformStruct extends Message<PlatformStruct> {
+  /**
+   * @generated from field: holos.v1alpha1.PlatformSpec spec = 1;
+   */
+  spec?: PlatformSpec;
+
+  constructor(data?: PartialMessage<PlatformStruct>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "holos.v1alpha1.PlatformStruct";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "spec", kind: "message", T: PlatformSpec },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): PlatformStruct {
+    return new PlatformStruct().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): PlatformStruct {
+    return new PlatformStruct().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): PlatformStruct {
+    return new PlatformStruct().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: PlatformStruct | PlainMessage<PlatformStruct> | undefined, b: PlatformStruct | PlainMessage<PlatformStruct> | undefined): boolean {
+    return proto3.util.equals(PlatformStruct, a, b);
+  }
+}
+
+/**
+ * @generated from message holos.v1alpha1.PlatformSpec
+ */
+export class PlatformSpec extends Message<PlatformSpec> {
+  /**
+   * @generated from field: holos.v1alpha1.PlatformSpecConfig config = 1;
+   */
+  config?: PlatformSpecConfig;
+
+  constructor(data?: PartialMessage<PlatformSpec>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "holos.v1alpha1.PlatformSpec";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "config", kind: "message", T: PlatformSpecConfig },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): PlatformSpec {
+    return new PlatformSpec().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): PlatformSpec {
+    return new PlatformSpec().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): PlatformSpec {
+    return new PlatformSpec().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: PlatformSpec | PlainMessage<PlatformSpec> | undefined, b: PlatformSpec | PlainMessage<PlatformSpec> | undefined): boolean {
+    return proto3.util.equals(PlatformSpec, a, b);
+  }
+}
+
+/**
+ * @generated from message holos.v1alpha1.PlatformSpecConfig
+ */
+export class PlatformSpecConfig extends Message<PlatformSpecConfig> {
+  /**
+   * @generated from field: holos.v1alpha1.UserDefinedConfig user = 1;
+   */
+  user?: UserDefinedConfig;
+
+  constructor(data?: PartialMessage<PlatformSpecConfig>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "holos.v1alpha1.PlatformSpecConfig";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "user", kind: "message", T: UserDefinedConfig },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): PlatformSpecConfig {
+    return new PlatformSpecConfig().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): PlatformSpecConfig {
+    return new PlatformSpecConfig().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): PlatformSpecConfig {
+    return new PlatformSpecConfig().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: PlatformSpecConfig | PlainMessage<PlatformSpecConfig> | undefined, b: PlatformSpecConfig | PlainMessage<PlatformSpecConfig> | undefined): boolean {
+    return proto3.util.equals(PlatformSpecConfig, a, b);
+  }
+}
+
+/**
+ * UserDefinedConfig represents user defined configuration values.
+ *
+ * @generated from message holos.v1alpha1.UserDefinedConfig
+ */
+export class UserDefinedConfig extends Message<UserDefinedConfig> {
+  /**
+   * @generated from field: map<string, holos.v1alpha1.UserDefinedSection> sections = 1;
+   */
+  sections: { [key: string]: UserDefinedSection } = {};
+
+  constructor(data?: PartialMessage<UserDefinedConfig>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "holos.v1alpha1.UserDefinedConfig";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "sections", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "message", T: UserDefinedSection} },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): UserDefinedConfig {
+    return new UserDefinedConfig().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): UserDefinedConfig {
+    return new UserDefinedConfig().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): UserDefinedConfig {
+    return new UserDefinedConfig().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: UserDefinedConfig | PlainMessage<UserDefinedConfig> | undefined, b: UserDefinedConfig | PlainMessage<UserDefinedConfig> | undefined): boolean {
+    return proto3.util.equals(UserDefinedConfig, a, b);
+  }
+}
+
+/**
+ * UserDefinedSection represents a user defined config section.
+ *
+ * @generated from message holos.v1alpha1.UserDefinedSection
+ */
+export class UserDefinedSection extends Message<UserDefinedSection> {
   /**
    * @generated from field: map<string, google.protobuf.Value> fields = 1;
    */
   fields: { [key: string]: Value } = {};
 
-  constructor(data?: PartialMessage<ConfigSection>) {
+  constructor(data?: PartialMessage<UserDefinedSection>) {
     super();
     proto3.util.initPartial(data, this);
   }
 
   static readonly runtime: typeof proto3 = proto3;
-  static readonly typeName = "holos.v1alpha1.ConfigSection";
+  static readonly typeName = "holos.v1alpha1.UserDefinedSection";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "fields", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "message", T: Value} },
   ]);
 
-  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ConfigSection {
-    return new ConfigSection().fromBinary(bytes, options);
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): UserDefinedSection {
+    return new UserDefinedSection().fromBinary(bytes, options);
   }
 
-  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): ConfigSection {
-    return new ConfigSection().fromJson(jsonValue, options);
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): UserDefinedSection {
+    return new UserDefinedSection().fromJson(jsonValue, options);
   }
 
-  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): ConfigSection {
-    return new ConfigSection().fromJsonString(jsonString, options);
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): UserDefinedSection {
+    return new UserDefinedSection().fromJsonString(jsonString, options);
   }
 
-  static equals(a: ConfigSection | PlainMessage<ConfigSection> | undefined, b: ConfigSection | PlainMessage<ConfigSection> | undefined): boolean {
-    return proto3.util.equals(ConfigSection, a, b);
-  }
-}
-
-/**
- * ConfigValues represents user defined configuration values.
- *
- * @generated from message holos.v1alpha1.ConfigValues
- */
-export class ConfigValues extends Message<ConfigValues> {
-  /**
-   * @generated from field: map<string, holos.v1alpha1.ConfigSection> sections = 1;
-   */
-  sections: { [key: string]: ConfigSection } = {};
-
-  constructor(data?: PartialMessage<ConfigValues>) {
-    super();
-    proto3.util.initPartial(data, this);
-  }
-
-  static readonly runtime: typeof proto3 = proto3;
-  static readonly typeName = "holos.v1alpha1.ConfigValues";
-  static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "sections", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "message", T: ConfigSection} },
-  ]);
-
-  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ConfigValues {
-    return new ConfigValues().fromBinary(bytes, options);
-  }
-
-  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): ConfigValues {
-    return new ConfigValues().fromJson(jsonValue, options);
-  }
-
-  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): ConfigValues {
-    return new ConfigValues().fromJsonString(jsonString, options);
-  }
-
-  static equals(a: ConfigValues | PlainMessage<ConfigValues> | undefined, b: ConfigValues | PlainMessage<ConfigValues> | undefined): boolean {
-    return proto3.util.equals(ConfigValues, a, b);
+  static equals(a: UserDefinedSection | PlainMessage<UserDefinedSection> | undefined, b: UserDefinedSection | PlainMessage<UserDefinedSection> | undefined): boolean {
+    return proto3.util.equals(UserDefinedSection, a, b);
   }
 }
 
@@ -758,9 +911,9 @@ export class PutPlatformConfigRequest extends Message<PutPlatformConfigRequest> 
   platformId = "";
 
   /**
-   * @generated from field: holos.v1alpha1.ConfigValues values = 2;
+   * @generated from field: holos.v1alpha1.UserDefinedConfig values = 2;
    */
-  values?: ConfigValues;
+  values?: UserDefinedConfig;
 
   constructor(data?: PartialMessage<PutPlatformConfigRequest>) {
     super();
@@ -771,7 +924,7 @@ export class PutPlatformConfigRequest extends Message<PutPlatformConfigRequest> 
   static readonly typeName = "holos.v1alpha1.PutPlatformConfigRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "platform_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 2, name: "values", kind: "message", T: ConfigValues },
+    { no: 2, name: "values", kind: "message", T: UserDefinedConfig },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): PutPlatformConfigRequest {

--- a/internal/frontend/holos/src/app/services/platform.service.ts
+++ b/internal/frontend/holos/src/app/services/platform.service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from '@angular/core';
 import { PlatformService as ConnectPlatformService } from '../gen/holos/v1alpha1/platform_connect';
 import { Observable, filter, of, switchMap } from 'rxjs';
 import { ObservableClient } from '../../connect/observable-client';
-import { Config, ConfigSection, ConfigValues, GetPlatformsRequest, Platform, PutPlatformConfigRequest } from '../gen/holos/v1alpha1/platform_pb';
+import { UserDefinedSection, UserDefinedConfig, GetPlatformsRequest, Platform, PutPlatformConfigRequest } from '../gen/holos/v1alpha1/platform_pb';
 import { Organization } from '../gen/holos/v1alpha1/organization_pb';
 import { Struct, Value } from '@bufbuild/protobuf';
 
@@ -39,10 +39,10 @@ export class PlatformService {
   }
 
   putConfig(id: string, model: Model): Observable<Platform> {
-    const values = new ConfigValues
+    const values = new UserDefinedConfig
     // Set string values from the model
     Object.keys(model).forEach(sectionName => {
-      values.sections[sectionName] = new ConfigSection
+      values.sections[sectionName] = new UserDefinedSection
       Object.keys(model[sectionName]).forEach(fieldName => {
         const val = new Value
         val.fromJson(model[sectionName][fieldName])

--- a/internal/platforms/bare/platform.cue
+++ b/internal/platforms/bare/platform.cue
@@ -22,4 +22,18 @@ package holos
 // #PlatformSpec represents configuration values defined by the platform
 // designer.  Config values are organized by section, then simple strings for
 // each section.
-#PlatformSpec: {[string]: {[string]: string | bool | [...string]}}
+#PlatformSpec: {
+	config: [string]: _
+	config: user:     #UserDefinedConfig
+}
+
+// #PlatformUserConfig represents configuration fields and values defined by the
+// user.
+#UserDefinedConfig: {
+	sections: [string]: fields: [string]: _
+}
+
+// #PlatformConfig represents the platform config data returned from the Holos API.  Useful for cue vet.
+#PlatformConfig: {
+	platform: spec: #PlatformSpec
+}

--- a/internal/platforms/bare/platform.holos.json
+++ b/internal/platforms/bare/platform.holos.json
@@ -1,1 +1,20 @@
-{"platform":{"spec":{"org":{"name":"ois"}}}}
+{
+  "platform": {
+    "spec": {
+      "config": {
+        "user": {
+          "sections": {
+            "org": {
+              "fields": {
+                "contactEmail": "jeff@openinfrastructure.co",
+                "displayName": "Open Infrastructure Services LLC",
+                "domain": "ois.run",
+                "name": "ois"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/server/handler/platform.go
+++ b/internal/server/handler/platform.go
@@ -56,7 +56,7 @@ func (h *PlatformHandler) AddPlatform(
 		}
 	}
 
-	var hv holos.ConfigValues
+	var hv holos.UserDefinedConfig
 	if len(req.Msg.Platform.RawConfig.Values) > 0 {
 		if err := json.Unmarshal(req.Msg.Platform.RawConfig.Values, &hv); err != nil {
 			return nil, connect.NewError(connect.CodeInvalidArgument, errors.Wrap(err))
@@ -167,7 +167,7 @@ func (h *PlatformHandler) PutPlatformConfig(ctx context.Context, req *connect.Re
 	return connect.NewResponse(&holos.GetPlatformResponse{Platform: PlatformToRPC(up)}), nil
 }
 
-func (h *PlatformHandler) GetConfig(ctx context.Context, req *connect.Request[holos.GetPlatformConfigRequest]) (*connect.Response[holos.ConfigValues], error) {
+func (h *PlatformHandler) GetConfig(ctx context.Context, req *connect.Request[holos.GetPlatformConfigRequest]) (*connect.Response[holos.PlatformConfig], error) {
 	authnID, err := authn.FromContext(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodePermissionDenied, errors.Wrap(err))
@@ -178,7 +178,17 @@ func (h *PlatformHandler) GetConfig(ctx context.Context, req *connect.Request[ho
 		return nil, errors.Wrap(err)
 	}
 
-	return connect.NewResponse(p.ConfigValues), nil
+	pc := &holos.PlatformConfig{
+		Platform: &holos.PlatformStruct{
+			Spec: &holos.PlatformSpec{
+				Config: &holos.PlatformSpecConfig{
+					User: p.ConfigValues,
+				},
+			},
+		},
+	}
+
+	return connect.NewResponse(pc), nil
 }
 
 func PlatformToRPC(platform *ent.Platform) *holos.Platform {

--- a/service/holos/v1alpha1/platform.proto
+++ b/service/holos/v1alpha1/platform.proto
@@ -25,16 +25,35 @@ message RawConfig {
 message Config {
   PlatformForm form = 1;
   // Values are the user supplied config values organized by section.
-  ConfigValues values = 2;
+  UserDefinedConfig values = 2;
 }
 
-message ConfigSection {
+message PlatformConfig {
+  PlatformStruct platform = 1;
+}
+
+// PlatformConfig represents the platform config struct.  The JSON encoding of this message is directly usable in CUE.
+// TODO: consolidate PlatformStruct and Platform into one message type representing a Platform resource.
+message PlatformStruct {
+  PlatformSpec spec = 1;
+}
+
+message PlatformSpec {
+  PlatformSpecConfig config = 1;
+}
+
+message PlatformSpecConfig {
+  UserDefinedConfig user = 1;
+}
+
+// UserDefinedConfig represents user defined configuration values.
+message UserDefinedConfig {
+  map<string, UserDefinedSection> sections = 1;
+}
+
+// UserDefinedSection represents a user defined config section.
+message UserDefinedSection {
   map<string, google.protobuf.Value> fields = 1;
-}
-
-// ConfigValues represents user defined configuration values.
-message ConfigValues {
-  map<string, ConfigSection> sections = 1;
 }
 
 message Platform {
@@ -48,6 +67,7 @@ message Platform {
   string name = 4 [(buf.validate.field).string.max_len = 100];
   string display_name = 5 [(buf.validate.field).string.max_len = 100];
   Creator creator = 6;
+
   // config represents the platform config form and values.  Read only.
   Config config = 7;
   // raw_config represents the platform config form and values.  Write only.
@@ -111,7 +131,7 @@ message PlatformForm {
 
 message PutPlatformConfigRequest {
   string platform_id = 1 [(buf.validate.field).string.uuid = true];
-  ConfigValues values = 2;
+  UserDefinedConfig values = 2;
 }
 
 message GetPlatformConfigRequest {
@@ -124,5 +144,5 @@ service PlatformService {
   rpc GetPlatform(GetPlatformRequest) returns (GetPlatformResponse) {}
   rpc PutPlatformConfig(PutPlatformConfigRequest) returns (GetPlatformResponse) {}
   // GetConfig provides the unmarshalled config values for use with CUE
-  rpc GetConfig(GetPlatformConfigRequest) returns (ConfigValues) {}
+  rpc GetConfig(GetPlatformConfigRequest) returns (PlatformConfig) {}
 }


### PR DESCRIPTION
See #150 

Problem:
The GetConfig response value isn't directly usable with CUE without some
gymnastics.

Solution:
Refactor the protobuf definition and response output to make the user
defined and supplied config values provided by the API directly usable
in the CUE code that defines the platform.

Result:

The top level platform config is directly usable in the
`internal/platforms/bare` directory:

    grpcurl -H "x-oidc-id-token: $(holos token)" -d '{"platform_id":"'${platformID}'"}' $host \
      holos.v1alpha1.PlatformService.GetConfig \
      > platform.holos.json

Vet the user supplied data:

    cue vet ./ -d '#PlatformConfig' platform.holos.json

Build the holos component.  The ConfigMap consumes the user supplied
data:

    cue export --out yaml -t cluster=k2 ./components/configmap platform.holos.json \
      | yq .spec.components

Note the data provided by the input form is embedded into the
ConfigMap managed by Holos:

```yaml
KubernetesObjectsList:
  - metadata:
      name: platform-configmap
    apiObjectMap:
      ConfigMap:
        platform: |
          metadata:
            name: platform
            namespace: default
            labels:
              app.holos.run/managed: "true"
          data:
            platform: |
              kind: Platform
              spec:
                config:
                  user:
                    sections:
                      org:
                        fields:
                          contactEmail: jeff@openinfrastructure.co
                          displayName: Open Infrastructure Services LLC
                          domain: ois.run
                          name: ois
              apiVersion: app.holos.run/v1alpha1
              metadata:
                name: bare
                labels: {}
                annotations: {}
              holos:
                flags:
                  cluster: k2
          kind: ConfigMap
          apiVersion: v1
    Skip: false
```

