### PR TITLE
(#150) Wire up select and multi select boxes

### DIFF
--- a/internal/frontend/holos/src/app/gen/holos/v1alpha1/platform_pb.ts
+++ b/internal/frontend/holos/src/app/gen/holos/v1alpha1/platform_pb.ts
@@ -429,110 +429,11 @@ export class Platform extends Message<Platform> {
 }
 
 /**
- * @generated from message holos.v1alpha1.FieldConfigProps
- */
-export class FieldConfigProps extends Message<FieldConfigProps> {
-  /**
-   * @generated from field: string label = 1;
-   */
-  label = "";
-
-  /**
-   * @generated from field: string placeholder = 2;
-   */
-  placeholder = "";
-
-  /**
-   * @generated from field: string description = 3;
-   */
-  description = "";
-
-  /**
-   * @generated from field: bool required = 4;
-   */
-  required = false;
-
-  constructor(data?: PartialMessage<FieldConfigProps>) {
-    super();
-    proto3.util.initPartial(data, this);
-  }
-
-  static readonly runtime: typeof proto3 = proto3;
-  static readonly typeName = "holos.v1alpha1.FieldConfigProps";
-  static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "label", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 2, name: "placeholder", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 3, name: "description", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 4, name: "required", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
-  ]);
-
-  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): FieldConfigProps {
-    return new FieldConfigProps().fromBinary(bytes, options);
-  }
-
-  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): FieldConfigProps {
-    return new FieldConfigProps().fromJson(jsonValue, options);
-  }
-
-  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): FieldConfigProps {
-    return new FieldConfigProps().fromJsonString(jsonString, options);
-  }
-
-  static equals(a: FieldConfigProps | PlainMessage<FieldConfigProps> | undefined, b: FieldConfigProps | PlainMessage<FieldConfigProps> | undefined): boolean {
-    return proto3.util.equals(FieldConfigProps, a, b);
-  }
-}
-
-/**
- * @generated from message holos.v1alpha1.FieldConfig
- */
-export class FieldConfig extends Message<FieldConfig> {
-  /**
-   * @generated from field: string key = 1;
-   */
-  key = "";
-
-  /**
-   * @generated from field: string type = 2;
-   */
-  type = "";
-
-  /**
-   * @generated from field: holos.v1alpha1.FieldConfigProps props = 3;
-   */
-  props?: FieldConfigProps;
-
-  constructor(data?: PartialMessage<FieldConfig>) {
-    super();
-    proto3.util.initPartial(data, this);
-  }
-
-  static readonly runtime: typeof proto3 = proto3;
-  static readonly typeName = "holos.v1alpha1.FieldConfig";
-  static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 2, name: "type", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 3, name: "props", kind: "message", T: FieldConfigProps },
-  ]);
-
-  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): FieldConfig {
-    return new FieldConfig().fromBinary(bytes, options);
-  }
-
-  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): FieldConfig {
-    return new FieldConfig().fromJson(jsonValue, options);
-  }
-
-  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): FieldConfig {
-    return new FieldConfig().fromJsonString(jsonString, options);
-  }
-
-  static equals(a: FieldConfig | PlainMessage<FieldConfig> | undefined, b: FieldConfig | PlainMessage<FieldConfig> | undefined): boolean {
-    return proto3.util.equals(FieldConfig, a, b);
-  }
-}
-
-/**
+ * TODO: add a metadata message to make it easier for the client to adapt the
+ * FieldConfigs into an es FormlyFieldConfig[].
+ * TODO: rename fieldConfigs to fields to align with how it's used everywhere
+ * else and with the formly documentation.
+ *
  * @generated from message holos.v1alpha1.ConfigFormSection
  */
 export class ConfigFormSection extends Message<ConfigFormSection> {
@@ -552,9 +453,24 @@ export class ConfigFormSection extends Message<ConfigFormSection> {
   description = "";
 
   /**
-   * @generated from field: repeated holos.v1alpha1.FieldConfig fieldConfigs = 4;
+   * NOTE: On the wire, carry any JSON as field configs for expedience.  I
+   * attempted to reflect FormlyFieldConfig in protobuf, but it was too time
+   * consuming.  The loosely defined Formly json data API creates significant
+   * friction when joined with a well defined protobuf API.  Therefore, we do
+   * not specify anything about the Forms API, convey any valid JSON, and leave
+   * it up to CUE and Formly on the sending and receiving side of the API.
+   *
+   * We use CUE to define our own holos form elements as a subset of the loose
+   * Formly definitions.  We further hope Formly will move toward a better JSON
+   * data API, but it's unlikely.  Consider replacing Formly entirely and
+   * building on top of the strongly typed Angular Dyanmic Forms API.
+   *
+   * Refer to: https://github.com/ngx-formly/ngx-formly/blob/v6.3.0/src/core/src/lib/models/fieldconfig.ts#L15
+   * Consider: https://angular.io/guide/dynamic-form
+   *
+   * @generated from field: repeated google.protobuf.Value fieldConfigs = 4;
    */
-  fieldConfigs: FieldConfig[] = [];
+  fieldConfigs: Value[] = [];
 
   constructor(data?: PartialMessage<ConfigFormSection>) {
     super();
@@ -567,7 +483,7 @@ export class ConfigFormSection extends Message<ConfigFormSection> {
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "displayName", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 3, name: "description", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 4, name: "fieldConfigs", kind: "message", T: FieldConfig, repeated: true },
+    { no: 4, name: "fieldConfigs", kind: "message", T: Value, repeated: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ConfigFormSection {

--- a/internal/frontend/holos/src/app/nav/nav.component.scss
+++ b/internal/frontend/holos/src/app/nav/nav.component.scss
@@ -13,7 +13,7 @@
 .mat-toolbar.mat-primary {
   position: sticky;
   top: 0;
-  z-index: 1;
+  z-index: 1000;
 }
 
 .toolbar-spacer {

--- a/internal/frontend/holos/src/app/views/platform-detail/platform-detail.component.html
+++ b/internal/frontend/holos/src/app/views/platform-detail/platform-detail.component.html
@@ -1,25 +1,28 @@
-<mat-tab-group>
-  <mat-tab label="Detail">
-    <div class="grid-container">
-    @if (platform$ | async; as platform) {
-      <form [formGroup]="form" (ngSubmit)="onSubmit(model)">
-        @for (section of platform.config?.form?.spec?.sections; track section.name) {
-          <h2>{{section.displayName ? section.displayName : section.name }}</h2>
-          <p>{{ section.description }}</p>
-          <formly-form [form]="form" [fields]="section.fieldConfigs" [model]="model[section.name]"></formly-form>
-        }
-        <p></p>
-        <button type="submit" mat-flat-button color="primary">Submit</button>
-      </form>
-    }
-    </div>
-  </mat-tab>
-
-  <mat-tab label="Raw">
-    <div class="grid-container">
+<div class="content-container">
+  <mat-tab-group>
+    <mat-tab label="Detail">
       @if (platform$ | async; as platform) {
-        <pre>{{ platform | json }}</pre>
+        <form [formGroup]="form" (ngSubmit)="onSubmit(model)">
+          @for (section of sections; track section.name) {
+            <div class="grid-container">
+              <h2>{{section.displayName ? section.displayName : section.name }}</h2>
+              <p>{{ section.description }}</p>
+              <formly-form [form]="form" [fields]="section.fields" [model]="model[section.name]"></formly-form>
+            </div>
+          }
+          <div class="grid-container">
+            <button type="submit" mat-flat-button color="primary">Submit</button>
+          </div>
+        </form>
       }
-    </div>
-  </mat-tab>
-</mat-tab-group>
+    </mat-tab>
+
+    <mat-tab label="Raw">
+      <div class="grid-container">
+        @if (platform$ | async; as platform) {
+          <pre>{{ platform | json }}</pre>
+        }
+      </div>
+    </mat-tab>
+  </mat-tab-group>
+</div>

--- a/internal/frontend/holos/src/app/views/platform-detail/platform-detail.component.ts
+++ b/internal/frontend/holos/src/app/views/platform-detail/platform-detail.component.ts
@@ -6,23 +6,31 @@ import { MatTab, MatTabGroup } from '@angular/material/tabs';
 import { AsyncPipe, CommonModule } from '@angular/common';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { FormlyMaterialModule } from '@ngx-formly/material';
-import { FormlyModule } from '@ngx-formly/core';
+import { FormlyFieldConfig, FormlyModule } from '@ngx-formly/core';
 import { MatButton } from '@angular/material/button';
 import { MatDivider } from '@angular/material/divider';
+import { Value } from '@bufbuild/protobuf';
+
+type Section = {
+  name: string
+  displayName: string
+  description: string
+  fields: FormlyFieldConfig[]
+}
 
 @Component({
   selector: 'app-platform-detail',
   standalone: true,
   imports: [
-    MatTabGroup,
-    MatTab,
     AsyncPipe,
     CommonModule,
-    FormlyModule,
-    ReactiveFormsModule,
     FormlyMaterialModule,
+    FormlyModule,
     MatButton,
     MatDivider,
+    MatTab,
+    MatTabGroup,
+    ReactiveFormsModule,
   ],
   templateUrl: './platform-detail.component.html',
   styleUrl: './platform-detail.component.scss'
@@ -35,12 +43,24 @@ export class PlatformDetailComponent {
 
   form = new FormGroup({});
   model: Model = {};
+  sections: Section[] = [];
 
   onSubmit(model: Model) {
-    console.log(model)
-    // if (this.form.valid) {
-    this.service.putConfig(this.platformId, model).pipe(shareReplay(1)).subscribe()
-    // }
+    if (this.form.valid) {
+      this.service.putConfig(this.platformId, model).pipe(shareReplay(1)).subscribe()
+    }
+  }
+
+  // rpcFieldsToFormlyFields adapts a protobuf Value[] to a typescript
+  // FormlyFieldConfig[].  Necessary to ensure select fields get scalar values,
+  // not google.protobuf.Value objects.  If objects are passed instead of
+  // scalars you may receive `ERROR Error: `compareWith` must be a function.`
+  // Refer to
+  // https://github.com/ngx-formly/ngx-formly/issues/2408#issuecomment-666686211
+  rpcFieldsToFormlyFields(fields: Value[]): FormlyFieldConfig[] {
+    const ffcs: FormlyFieldConfig[] = []
+    fields.forEach(field => { ffcs.push(JSON.parse(JSON.stringify(field))) })
+    return ffcs
   }
 
   @Input()
@@ -49,15 +69,31 @@ export class PlatformDetailComponent {
     this.platform$ = this.service.getPlatform(platformId).pipe(
       map(project => {
         // Initialize the model container for each section of the form config
-        project.config?.form?.spec?.sections.forEach(section => {
-          this.model[section.name] = {}
-        })
-        // Load existing values into the form
-        const sections = project.config?.values?.sections
-        if (sections !== undefined) {
-          Object.keys(sections).forEach(sectionName => {
-            Object.keys(sections[sectionName].fields).forEach(fieldName => {
-              this.model[sectionName][fieldName] = sections[sectionName].fields[fieldName].toJson()
+        const formSections = project.config?.form?.spec?.sections
+        if (formSections !== undefined) {
+          formSections.forEach(section => {
+            // Map the pb FieldConfig[] to es FormlyFieldConfig[] so we get
+            // scalar values, not objects as are provided by
+            // google.protobuf.Value.
+            const jsSection: Section = {
+              name: section.name,
+              displayName: section.displayName,
+              description: section.description,
+              fields: this.rpcFieldsToFormlyFields(section.fieldConfigs),
+            }
+            this.sections.push(jsSection)
+            // Initialize the model for the section
+            this.model[section.name] = {}
+          })
+        }
+
+        // Upstream docs recommend loading values into the model instead of
+        // using the defaultValue FormlyFormConfig property.
+        const modelSections = project.config?.values?.sections
+        if (modelSections !== undefined) {
+          Object.keys(modelSections).forEach(sectionName => {
+            Object.keys(modelSections[sectionName].fields).forEach(fieldName => {
+              this.model[sectionName][fieldName] = modelSections[sectionName].fields[fieldName].toJson()
             })
           })
         }

--- a/internal/platforms/bare/forms/platform/platform-form.cue
+++ b/internal/platforms/bare/forms/platform/platform-form.cue
@@ -11,29 +11,97 @@ let Platform = formsv1.#Platform & {
 		description: "Organization config values are used to derive more specific configuration values throughout the platform."
 
 		fieldConfigs: {
-			// platform.org.name
+			// platform.spec.config.user.sections.org.fields.name
 			name: props: {
 				label:       "Name"
 				placeholder: "example"
 				description: "DNS label, e.g. 'example'"
 			}
-			// platform.org.domain
+			// platform.spec.config.user.sections.org.fields.domain
 			domain: props: {
 				label:       "Domain"
 				placeholder: "example.com"
 				description: "DNS domain, e.g. 'example.com'"
 			}
-			// platform.org.displayName
+			// platform.spec.config.user.sections.org.fields.displayName
 			displayName: props: {
 				label:       "Display Name"
 				placeholder: "Example Organization"
 				description: "Display name, e.g. 'Example Organization'"
 			}
-			// platform.org.contactEmail
-			contactEmail: props: {
-				label:       "Contact Email"
-				placeholder: "platform-team@example.com"
-				description: "Technical contact email address"
+			// platform.spec.config.user.sections.org.fields.contactEmail
+			contactEmail: {
+				props: {
+					label:       "Contact Email"
+					placeholder: "platform-team@example.com"
+					description: "Technical contact email address"
+				}
+			}
+		}
+	}
+
+	sections: privacy: {
+		displayName: "Data Privacy"
+		description: "Configure data privacy aspects of the platform."
+
+		fieldConfigs: {
+			country: {
+				// https://formly.dev/docs/api/ui/material/select/
+				type: "select"
+				props: {
+					label:       "Select Planet"
+					description: "Juridiction of applicable data privacy laws."
+					options: [
+						{value: "mercury", label: "Mercury"},
+						{value: "venus", label:   "Venus"},
+						{value: "earth", label:   "Earth"},
+						{value: "mars", label:    "Mars"},
+						{value: "jupiter", label: "Jupiter"},
+						{value: "saturn", label:  "Saturn"},
+						{value: "uranus", label:  "Uranus"},
+						{value: "neptune", label: "Neptune"},
+					]
+				}
+			}
+			regions: {
+				// https://formly.dev/docs/api/ui/material/select/
+				type: "select"
+				props: {
+					label:           "Select Regions"
+					description:     "Select the regions this platform operates in."
+					multiple:        true
+					selectAllOption: "Select All"
+					options: [
+						{value: "us-east-2", label: "Ohio"},
+						{value: "us-west-2", label: "Oregon"},
+						{value: "eu-west-1", label: "Ireland"},
+						{value: "eu-west-2", label: "London", disabled: true},
+					]
+				}
+			}
+		}
+	}
+
+	// https://v5.formly.dev/ui/material
+	sections: terms: {
+		displayName: "Terms and Conditions"
+		description: "Example of a boolean checkbox."
+
+		fieldConfigs: {
+			// platform.spec.config.user.sections.terms.fields.didAgree
+			didAgree: {
+				type: "checkbox"
+				props: {
+					label:       "Accept terms"
+					description: "In order to proceed, please accept terms"
+					pattern:     "true"
+					required:    true
+				}
+				validation: {
+					messages: {
+						pattern: "Please accept the terms"
+					}
+				}
 			}
 		}
 	}

--- a/internal/platforms/cue.mod/pkg/github.com/holos-run/forms/v1alpha1/forms.cue
+++ b/internal/platforms/cue.mod/pkg/github.com/holos-run/forms/v1alpha1/forms.cue
@@ -53,13 +53,60 @@ package v1alpha1
 }
 
 // Refer to https://formly.dev/docs/api/core#formlyfieldconfig
+// Refer to https://formly.dev/docs/api/ui/material/select
 #FieldConfig: {
 	key:  string
-	type: "input"
+	type: string | *"input" | "select" | "checkbox"
+	// Refer to: https://formly.dev/docs/api/ui/material/select#formlyselectprops
+	// and other input field select props.
 	props: {
-		label:       string
-		placeholder: string
-		description: string
-		required:    *true | false
+		#FormlySelectProps
+
+		label:        string
+		placeholder?: string
+		description:  string
+		required?:    *true | false
+		pattern?:     string
+		minLength?:   number
+		maxLength?:   number
 	}
+	// Refer to: https://github.com/ngx-formly/ngx-formly/blob/v6.3.0/src/core/src/lib/models/fieldconfig.ts#L49-L64
+	// We support only the string form.
+	validation?: {
+		// Note, you can set messages for pattern, minLength, maxLength here.
+		messages?: [string]: string
+	}
+
+	// Refer to: https://github.com/ngx-formly/ngx-formly/blob/v6.3.0/src/core/src/lib/models/fieldconfig.ts#L115-L120
+	expressions?: [string]: string
+	hide?: true | false
+	// Required to populate protobuf value.
+	resetOnHide:   *true | false
+	defaultValue?: _
+	className?:    string
+	fieldGroup?: [...#FieldConfig]
+	focus?: true | *false
+	modelOptions?: {
+		debounce?: {
+			default: number
+		}
+		updateOn?: "change" | "blur" | "submit"
+	}
+}
+
+// Refer to https://formly.dev/docs/api/ui/material/select#formlyselectprops
+#FormlySelectProps: {
+	disableOptionCentering?:    true | false
+	multiple?:                  true | false
+	panelClass?:                string
+	selectAllOption?:           string
+	typeaheadDebounceInterval?: number
+
+	options?: [...{value: string | number | bool, label: string, disabled?: true | *false}]
+
+	// These could be used to set different keys for value and label in the
+	// options list, but we don't support that level of customization.
+	// They're here for documentation purposes only.
+	labelProp?: "label"
+	valueProp?: "value"
 }

--- a/service/holos/v1alpha1/platform.proto
+++ b/service/holos/v1alpha1/platform.proto
@@ -74,24 +74,30 @@ message Platform {
   RawConfig raw_config = 8;
 }
 
-message FieldConfigProps {
-  string label = 1;
-  string placeholder = 2;
-  string description = 3;
-  bool required = 4;
-}
-
-message FieldConfig {
-  string key = 1;
-  string type = 2;
-  FieldConfigProps props = 3;
-}
-
+// TODO: add a metadata message to make it easier for the client to adapt the
+// FieldConfigs into an es FormlyFieldConfig[].
+// TODO: rename fieldConfigs to fields to align with how it's used everywhere
+// else and with the formly documentation.
 message ConfigFormSection {
   string name = 1;
   string displayName = 2;
   string description = 3;
-  repeated FieldConfig fieldConfigs = 4;
+
+  // NOTE: On the wire, carry any JSON as field configs for expedience.  I
+  // attempted to reflect FormlyFieldConfig in protobuf, but it was too time
+  // consuming.  The loosely defined Formly json data API creates significant
+  // friction when joined with a well defined protobuf API.  Therefore, we do
+  // not specify anything about the Forms API, convey any valid JSON, and leave
+  // it up to CUE and Formly on the sending and receiving side of the API.
+  //
+  // We use CUE to define our own holos form elements as a subset of the loose
+  // Formly definitions.  We further hope Formly will move toward a better JSON
+  // data API, but it's unlikely.  Consider replacing Formly entirely and
+  // building on top of the strongly typed Angular Dyanmic Forms API.
+  //
+  // Refer to: https://github.com/ngx-formly/ngx-formly/blob/v6.3.0/src/core/src/lib/models/fieldconfig.ts#L15
+  // Consider: https://angular.io/guide/dynamic-form
+  repeated google.protobuf.Value fieldConfigs = 4;
 }
 
 message PlatformFormSpec {


### PR DESCRIPTION
This patch wires up a Select and a Multi Select box.  This patch also
establishes a decision as it relates to Formly TypeScript / gRPC Proto3
/ CUE definitions of the form data structure.  The decision is to use
gRPC as a transport for any JSON to avoid friction trying to fit Formly
types into Proto3 messages.

Note when using google.protobuf.Value messages with bufbuild/connect-es,
we need to round trip them one last time through JSON to get the
original JSON on the other side.  This is because connect-es preserves
the type discriminators in the case and value fields of the message.

Refer to: [Accessing oneof
groups](https://github.com/bufbuild/protobuf-es/blob/main/docs/runtime_api.md#accessing-oneof-groups)

NOTE: On the wire, carry any JSON as field configs for expedience.  I
attempted to reflect FormlyFieldConfig in protobuf, but it was too time
consuming.  The loosely defined Formly json data API creates significant
friction when joined with a well defined protobuf API.  Therefore, we do
not specify anything about the Forms API, convey any valid JSON, and
leave it up to CUE and Formly on the sending and receiving side of the
API.

We use CUE to define our own holos form elements as a subset of the loose
Formly definitions.  We further hope Formly will move toward a better JSON
data API, but it's unlikely.  Consider replacing Formly entirely and
building on top of the strongly typed Angular Dyanmic Forms API.

Refer to: https://github.com/ngx-formly/ngx-formly/blob/v6.3.0/src/core/src/lib/models/fieldconfig.ts#L15
Consider: https://angular.io/guide/dynamic-form

Usage:

Generate the form from CUE

    cue export ./forms/platform/ --out json | jq -cM | pbcopy

Store the form JSON in the config_values column of the platforms table.

View the form, and submit some data. Then get the data back out for use rendering the platform:

    grpcurl -H "x-oidc-id-token: $(holos token)" -d '{"platform_id":"'${platformId}'"}' $holos holos.v1alpha1.PlatformService.GetConfig

```json
{
  "platform": {
    "spec": {
      "config": {
        "user": {
          "sections": {
            "org": {
              "fields": {
                "contactEmail": "jeff@openinfrastructure.co",
                "displayName": "Open Infrastructure Services LLC",
                "domain": "ois.run",
                "name": "ois"
              }
            },
            "privacy": {
              "fields": {
                "country": "earth",
                "regions": [
                  "us-east-2",
                  "us-west-2"
                ]
              }
            },
            "terms": {
              "fields": {
                "didAgree": true
              }
            }
          }
        }
      }
    }
  }
}
```

