### PR TITLE
(#181) Add AuthorizationPolicy resources for admin interfaces

### DIFF
--- a/internal/generate/platforms/holos/apps/dev/holos/app/dev-holos-app.cue
+++ b/internal/generate/platforms/holos/apps/dev/holos/app/dev-holos-app.cue
@@ -3,6 +3,8 @@ package holos
 // Produce a kubernetes objects build plan.
 (#Kubernetes & Objects).Output
 
+let Image = "quay.io/holos-run/holos:v0.83.1-7-gd9fe32b"
+
 _AppInfo: spec: component: "app"
 
 let Objects = {
@@ -59,7 +61,7 @@ let Objects = {
 						containers: [
 							{
 								name:            Metadata.name
-								image:           "quay.io/holos-run/holos:v0.83.1"
+								image:           Image
 								imagePullPolicy: "IfNotPresent"
 								command: [
 									"/app/bin/holos",

--- a/internal/generate/platforms/holos/components/istio/mesh/iap/authpolicy/authpolicy.cue
+++ b/internal/generate/platforms/holos/components/istio/mesh/iap/authpolicy/authpolicy.cue
@@ -7,17 +7,19 @@ let Objects = {
 	Name:      "authpolicy"
 	Namespace: _AuthProxy.metadata.namespace
 
-	let Metadata = _IAP.metadata
 	let Selector = {matchLabels: "istio.io/gateway-name": "default"}
 
-	Resources: [_]: [_]: metadata: namespace: Namespace
+	Resources: [_]: [NAME=string]: {
+		metadata: _IAP.metadata
+		metadata: name:      NAME
+		metadata: namespace: Namespace
+	}
 
 	// Auth policy resources represent the RequestAuthentication and
 	// AuthorizationPolicy resources in the istio-gateways namespace governing the
 	// default Gateway.
 	Resources: {
 		RequestAuthentication: (Name): {
-			metadata: Metadata & {name: Name}
 			spec: jwtRules: [{
 				audiences: ["\(_AuthProxy.projectID)"]
 				forwardOriginalToken: true
@@ -30,7 +32,6 @@ let Objects = {
 		AuthorizationPolicy: "\(Name)-custom": {
 			_description: "Route all requests through the auth proxy by default"
 
-			metadata: Metadata & {name: "\(Name)-custom"}
 			spec: {
 				action: "CUSTOM"
 				provider: name: _AuthProxy.provider
@@ -58,5 +59,143 @@ let Objects = {
 				selector: Selector
 			}
 		}
+
+		AuthorizationPolicy: "\(Name)-allow-nothing": {
+			_description: "Allow nothing"
+
+			spec: {
+				action:   "ALLOW"
+				selector: Selector
+			}
+		}
+
+		AuthorizationPolicy: "\(Name)-allow-login": {
+			_description: "Allow login"
+
+			spec: {
+				action:   "ALLOW"
+				selector: Selector
+				rules: [
+					{
+						to: [{
+							// Refer to https://istio.io/latest/docs/ops/best-practices/security/#writing-host-match-policies
+							operation: hosts: [
+								// Allow requests to the login service
+								_AuthProxy.issuerHost,
+								_AuthProxy.issuerHost + ":*",
+							]
+						}]
+					},
+				]
+			}
+		}
+
+		AuthorizationPolicy: "\(Name)-allow-admin": {
+			_description: "Allow cluster admin roles"
+
+			spec: {
+				action:   "ALLOW"
+				selector: Selector
+				rules: [
+					{
+						to: [{
+							// Refer to https://istio.io/latest/docs/ops/best-practices/security/#writing-host-match-policies
+							operation: hosts: [
+								// Allow authenticated users with cluster admin, edit, or view
+								// roles to access admin interfaces.
+
+								// TODO(jeff): The set of admin services should be defined in a
+								// nice root-level struct somewhere, probably as part of the
+								// _Projects struct.
+								"argocd.admin.\(_ClusterName).\(_Platform.Model.org.domain)",
+								"argocd.admin.\(_ClusterName).\(_Platform.Model.org.domain):*",
+								"httpbin.admin.\(_ClusterName).\(_Platform.Model.org.domain)",
+								"httpbin.admin.\(_ClusterName).\(_Platform.Model.org.domain):*",
+								"backstage.admin.\(_ClusterName).\(_Platform.Model.org.domain)",
+								"backstage.admin.\(_ClusterName).\(_Platform.Model.org.domain):*",
+							]
+						}]
+						when: [
+							// Must be issued by the platform identity provider.
+							{
+								key: "request.auth.principal"
+								values: [_AuthProxy.issuerURL + "/*"]
+							},
+							// Must be intended for an app within the Holos Platform ZITADEL project.
+							{
+								key: "request.auth.audiences"
+								values: [_AuthProxy.projectID]
+							},
+							// Must be presented by the istio ExtAuthz auth proxy.
+							{
+								key: "request.auth.presenter"
+								values: [_AuthProxy.clientID]
+							},
+							// Must have one of the listed roles.
+							AdminRoleGroups,
+						]
+					},
+				]
+			}
+		}
+
+		AuthorizationPolicy: "\(Name)-allow-holos-server": {
+			_description: "Allow authenticated access to holos server"
+
+			spec: {
+				action:   "ALLOW"
+				selector: Selector
+				rules: [
+					{
+						to: [{
+							// Refer to https://istio.io/latest/docs/ops/best-practices/security/#writing-host-match-policies
+							operation: hosts: [
+								// Allow authenticated users with cluster admin, edit, or view
+								// roles to access admin interfaces.
+
+								// TODO(jeff): The set of admin services should be defined in a
+								// nice root-level struct somewhere, probably as part of the
+								// _Projects struct.
+								"app.\(_ClusterName).\(_Platform.Model.org.domain)",
+								"app.\(_ClusterName).\(_Platform.Model.org.domain):*",
+								"dev.app.\(_ClusterName).\(_Platform.Model.org.domain)",
+								"dev.app.\(_ClusterName).\(_Platform.Model.org.domain):*",
+
+								"app.\(_Platform.Model.org.domain)",
+								"app.\(_Platform.Model.org.domain):*",
+								"dev.app.\(_Platform.Model.org.domain)",
+								"dev.app.\(_Platform.Model.org.domain):*",
+							]
+						}]
+						when: [
+							// Must be issued by the platform identity provider.
+							{
+								key: "request.auth.principal"
+								values: [_AuthProxy.issuerURL + "/*"]
+							},
+							// Must be intended for an app within the Holos Platform ZITADEL project.
+							{
+								key: "request.auth.audiences"
+								values: [_AuthProxy.projectID]
+							},
+							// Must be presented by the istio ExtAuthz auth proxy.
+							{
+								key: "request.auth.presenter"
+								values: [_AuthProxy.clientID]
+							},
+						]
+					},
+				]
+			}
+		}
 	}
+}
+
+let AdminRoleGroups = {
+	key: "request.auth.claims[groups]"
+	values: [
+		"prod-cluster-admin",
+		"prod-cluster-edit",
+		"prod-cluster-view",
+	]
 }


### PR DESCRIPTION
Previously, when a user registered and logged into the holos app server,
they were able to reach admin interfaces like
https://argocd.admin.example.com

This patch adds AuthorizationPolicy resources governing the whole
cluster.  Users with the prod-cluster-{admin,edit,view} roles may access
admin services like argocd.

Users without these roles are blocked with RBAC: access denied.

In ZITADEL, the Holos Platform project is granted to the CIAM
organization without granting the prod-cluster-* roles, so there's no
possible way a CIAM user account can have these roles.


Closes: #181
