### PR TITLE
(#179) Use errorgroup SetLimit to limit concurrency

### DIFF
--- a/internal/render/platform.go
+++ b/internal/render/platform.go
@@ -15,36 +15,44 @@ import (
 
 func Platform(ctx context.Context, concurrency int, pf *v1alpha1.Platform, stderr io.Writer) error {
 	total := len(pf.Spec.Components)
-	// Limit the number of concurrent goroutines due to CUE memory usage concerns while rendering components.
-	sem := make(chan struct{}, concurrency)
-	eg, ctx := errgroup.WithContext(ctx)
 
-	for idx, component := range pf.Spec.Components {
-		// Capture idx and component to avoid issues with closure. Can be removed on Go 1.22.
-		idx, component := idx, component
+	g, ctx := errgroup.WithContext(ctx)
+	// Limit the number of concurrent goroutines due to CUE memory usage concerns
+	// while rendering components.  One more for the producer.
+	g.SetLimit(concurrency + 1)
 
-		eg.Go(func() error {
-			sem <- struct{}{}        // Acquire a slot
-			defer func() { <-sem }() // Release the slot when done
+	// Spawn a producer because g.Go() blocks when the group limit is reached.
+	g.Go(func() error {
+		for idx, component := range pf.Spec.Components {
+			select {
+			case <-ctx.Done():
+				return nil
+			default:
+				// Capture idx and component to avoid issues with closure. Can be removed on Go 1.22.
+				idx, component := idx, component
+				// Worker go routine.  Blocks if limit has been reached.
+				g.Go(func() error {
+					start := time.Now()
+					log := logger.FromContext(ctx).With("path", component.Path, "cluster", component.Cluster, "num", idx+1, "total", total)
+					log.DebugContext(ctx, "render component")
 
-			start := time.Now()
-			log := logger.FromContext(ctx).With("path", component.Path, "cluster", component.Cluster, "num", idx+1, "total", total)
-			log.DebugContext(ctx, "render component")
+					// Execute a sub-process to limit CUE memory usage.
+					args := []string{"render", "component", "--cluster-name", component.Cluster, component.Path}
+					result, err := util.RunCmd(ctx, "holos", args...)
+					if err != nil {
+						_, _ = io.Copy(stderr, result.Stderr)
+						return errors.Wrap(fmt.Errorf("could not render component: %w", err))
+					}
 
-			// Execute a sub-process to limit CUE memory usage.
-			args := []string{"render", "component", "--cluster-name", component.Cluster, component.Path}
-			result, err := util.RunCmd(ctx, "holos", args...)
-			if err != nil {
-				_, _ = io.Copy(stderr, result.Stderr)
-				return errors.Wrap(fmt.Errorf("could not render component: %w", err))
+					duration := time.Since(start)
+					log.InfoContext(ctx, "ok render component", "duration", duration)
+					return nil
+				})
 			}
-
-			duration := time.Since(start)
-			log.InfoContext(ctx, "ok render component", "duration", duration)
-			return nil
-		})
-	}
+		}
+		return nil
+	})
 
 	// Wait for completion and return the first error (if any)
-	return eg.Wait()
+	return g.Wait()
 }


### PR DESCRIPTION
Previously a channel was used to limit concurrency.  This is more
difficult to read and comprehend than the inbuilt errorgroup.SetLimit
functionality.

This patch uses `errgroup.`[Group.SetLimit()][1] to limit concurrency,
avoid leaking go routines, and avoid unnecessary work.

[1]: https://pkg.go.dev/golang.org/x/sync/errgroup#Group.SetLimit


Closes: #179
