### PR TITLE
cli/delete: improve platform deletion help text and output

### DIFF
--- a/internal/cli/destroy/delete.go
+++ b/internal/cli/destroy/delete.go
@@ -31,6 +31,8 @@ func New(cfg *holos.Config) *cobra.Command {
 func NewPlatform(cfg *client.Config) *cobra.Command {
 	cmd := command.New("platform")
 	cmd.Args = cobra.MinimumNArgs(1)
+	cmd.Use = "platform [flags] PLATFORM_ID [PLATFORM_ID ...]"
+	cmd.Short = "Delete one or more platforms by ID"
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Root().Context()
@@ -41,7 +43,8 @@ func NewPlatform(cfg *client.Config) *cobra.Command {
 			if err != nil {
 				return errors.Wrap(err)
 			}
-			fmt.Fprintln(cmd.OutOrStdout(), "deleted platform", msg.GetPlatform().GetName())
+			platform := msg.GetPlatform()
+			fmt.Fprintf(cmd.OutOrStdout(), "deleted platform %s (%s)\n", platform.GetName(), platform.GetId())
 		}
 
 		return nil


### PR DESCRIPTION
- Clarify help text to indicate one or more platform IDs as arguments.
- Show platform name and ID in `delete platform` output for clarity.

## Help Text

Before this change:

```console
$ holos delete platform --help                                          
platform

Usage:
  holos delete platform [flags]

Flags:
  -h, --help      help for platform
  -v, --version   version for platform

Global Flags:
      --log-drop strings    log attributes to drop (example "user-agent,version")
      --log-format string   log format (text|json) (default "text")
      --log-level string    log level (debug|info|warn|error) (default "info")
```

After this change:

```console
$ holos delete platform --help            
Delete one or more platforms by ID

Usage:
  holos delete platform [flags] PLATFORM_ID [PLATFORM_ID ...]

Flags:
  -h, --help      help for platform
  -v, --version   version for platform

Global Flags:
      --log-drop strings    log attributes to drop (example "user-agent,version")
      --log-format string   log format (text|json) (default "text")
      --log-level string    log level (debug|info|warn|error) (default "info")
```

## Output

Before this change:

```console
$ holos delete platform 0190d1dd-2201-7277-8bd8-4025bf561af3 0190d1dd-1e78-7d81-81d5-5edf01afa712 0190d1dd-192a-7d81-ae55-5bd8698522c3
deleted platform rand-11805
deleted platform rand-2217
deleted platform rand-963
```

After this change:

```console
$ holos delete platform 0190d1dd-2201-7277-8bd8-4025bf561af3 0190d1dd-1e78-7d81-81d5-5edf01afa712 0190d1dd-192a-7d81-ae55-5bd8698522c3
deleted platform rand-11805 (0190d1dd-2201-7277-8bd8-4025bf561af3)
deleted platform rand-2217 (0190d1dd-1e78-7d81-81d5-5edf01afa712)
deleted platform rand-963 (0190d1dd-192a-7d81-ae55-5bd8698522c3)
```