### PR TITLE
builder: fill #UserData from userdata/**/*.json (#210)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -36,7 +36,9 @@
     "killall",
     "kubeadm",
     "kubeconfig",
+    "Kustomization",
     "kustomize",
+    "ldflags",
     "libnss",
     "loadbalancer",
     "mattn",
@@ -67,6 +69,7 @@
     "Upsert",
     "urandom",
     "userconnect",
+    "userdata",
     "zerolog",
     "zitadel"
   ]

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,12 @@
+# Refer to https://ko.build/configuration/#overriding-go-build-settings
+builds:
+- id: holos
+  dir: .
+  main: ./cmd/holos
+  env:
+  - GOPRIVATE=github.com/holos-run/\*
+  ldflags:
+  - -s
+  - -w
+  - -X
+  - github.com/holos-run/holos/version.GitDescribe={{.Env.GIT_DETAIL}}{{.Env.GIT_SUFFIX}}

--- a/Makefile
+++ b/Makefile
@@ -137,9 +137,13 @@ frontend-deps: ## Install Angular deps for go generate
 website-deps: ## Install Docusaurus deps for go generate
 	cd doc/website && npm install
 
-.PHONY: image
+.PHONY: image # refer to .ko.yaml as well
 image:  ## Container image build
-	KO_DOCKER_REPO=$(DOCKER_REPO) ko build --platform=all --bare ./cmd/holos --tags $(shell git describe --tags) --tags latest
+	KO_DOCKER_REPO=$(DOCKER_REPO) GIT_DETAIL=$(GIT_DETAIL) GIT_SUFFIX=$(GIT_SUFFIX) ko build --platform=all --bare ./cmd/holos --tags $(GIT_DETAIL)$(GIT_SUFFIX)
+
+.PHONY: deploy
+deploy: image  ## DEPLOY TO PROD
+	GIT_DETAIL=$(GIT_DETAIL) GIT_SUFFIX=$(GIT_SUFFIX) bash ./hack/deploy
 
 .PHONY: website
 website: ## Build website

--- a/hack/deploy
+++ b/hack/deploy
@@ -1,0 +1,25 @@
+#! /bin/bash
+#
+
+tmpdir="$(mktemp -d)"
+finish() {
+  rm -rf "$tmpdir"
+}
+trap finish EXIT
+
+set -euo pipefail
+
+: ${GIT_DETAIL:=$(git describe --tags HEAD)}
+: ${GIT_SUFFIX:=$(test -n "`git status --porcelain`" && echo "-dirty" || echo "")}
+
+cd "$tmpdir"
+git clone --depth 1 git@github.com:holos-run/holos-infra.git
+cd holos-infra/saas
+echo '{"HolosVersion":"'${GIT_DETAIL}${GIT_SUFFIX}'"}' > userdata/holos.json
+holos render platform ./platform
+git add .
+git commit -m "${GIT_DETAIL}${GIT_SUFFIX} [auto]"
+git --no-pager show --stat
+git push origin HEAD
+echo
+echo "https://argocd.admin.aws2.holos.run/applications/prod-holos-app"

--- a/internal/builder/platform.go
+++ b/internal/builder/platform.go
@@ -6,8 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"cuelang.org/go/cue/build"
-	"cuelang.org/go/cue/cuecontext"
 	"github.com/holos-run/holos"
 	core "github.com/holos-run/holos/api/core/v1alpha2"
 	meta "github.com/holos-run/holos/api/meta/v1alpha2"
@@ -20,37 +18,22 @@ import (
 func (b *Builder) Platform(ctx context.Context, cfg *client.Config) (*core.Platform, error) {
 	log := logger.FromContext(ctx)
 	log.DebugContext(ctx, "cue: building platform instance")
-	instances, err := b.Instances(ctx, cfg)
+	bd, err := b.Unify(ctx, cfg)
 	if err != nil {
 		return nil, errors.Wrap(err)
 	}
-
-	if len(instances) != 1 {
-		return nil, errors.Wrap(errors.New(fmt.Sprintf("instances length %d must be exactly 1", len(instances))))
-	}
-
-	// We only process the first instance, assume the render platform subcommand enforces this.
-	instance := instances[0]
-	log.DebugContext(ctx, "cue: building instance", "dir", instance.Dir)
-	p, err := b.runPlatform(ctx, instance)
-	if err != nil {
-		return nil, errors.Wrap(fmt.Errorf("could not build platform: %w", err))
-	}
-	return p, nil
+	return b.runPlatform(ctx, bd)
 }
 
-func (b Builder) runPlatform(ctx context.Context, instance *build.Instance) (*core.Platform, error) {
-	path := holos.InstancePath(instance.Dir)
+func (b Builder) runPlatform(ctx context.Context, bd BuildData) (*core.Platform, error) {
+	path := holos.InstancePath(bd.Dir)
 	log := logger.FromContext(ctx).With("dir", path)
 
-	if err := instance.Err; err != nil {
+	value := bd.Value
+	if err := bd.Value.Err(); err != nil {
 		return nil, errors.Wrap(fmt.Errorf("could not load: %w", err))
 	}
-	cueCtx := cuecontext.New()
-	value := cueCtx.BuildInstance(instance)
-	if err := value.Err(); err != nil {
-		return nil, errors.Wrap(fmt.Errorf("could not build %s: %w", instance.Dir, err))
-	}
+
 	log.DebugContext(ctx, "cue: validating instance")
 	if err := value.Validate(); err != nil {
 		return nil, errors.Wrap(fmt.Errorf("could not validate: %w", err))
@@ -59,7 +42,7 @@ func (b Builder) runPlatform(ctx context.Context, instance *build.Instance) (*co
 	log.DebugContext(ctx, "cue: decoding holos platform")
 	jsonBytes, err := value.MarshalJSON()
 	if err != nil {
-		return nil, errors.Wrap(fmt.Errorf("could not marshal cue instance %s: %w", instance.Dir, err))
+		return nil, errors.Wrap(fmt.Errorf("could not marshal cue instance %s: %w", bd.Dir, err))
 	}
 
 	decoder := json.NewDecoder(bytes.NewReader(jsonBytes))
@@ -67,7 +50,7 @@ func (b Builder) runPlatform(ctx context.Context, instance *build.Instance) (*co
 	tm := &meta.TypeMeta{}
 	err = decoder.Decode(tm)
 	if err != nil {
-		return nil, errors.Wrap(fmt.Errorf("invalid platform: %s: %w", instance.Dir, err))
+		return nil, errors.Wrap(fmt.Errorf("invalid platform: %s: %w", bd.Dir, err))
 	}
 
 	log.DebugContext(ctx, "cue: discriminated build kind: "+tm.GetKind(), "kind", tm.GetKind(), "apiVersion", tm.GetAPIVersion())
@@ -80,7 +63,7 @@ func (b Builder) runPlatform(ctx context.Context, instance *build.Instance) (*co
 	switch tm.GetKind() {
 	case "Platform":
 		if err = decoder.Decode(&pf); err != nil {
-			err = errors.Wrap(fmt.Errorf("could not decode platform %s: %w", instance.Dir, err))
+			err = errors.Wrap(fmt.Errorf("could not decode platform %s: %w", bd.Dir, err))
 			return nil, err
 		}
 		return &pf, nil

--- a/internal/cli/build/build.go
+++ b/internal/cli/build/build.go
@@ -43,8 +43,8 @@ func makeBuildRunFunc(cfg *client.Config) command.RunFunc {
 
 // New returns the build subcommand for the root command
 func New(cfg *holos.Config) *cobra.Command {
-	cmd := command.New("build [directory...]")
-	cmd.Args = cobra.MinimumNArgs(1)
+	cmd := command.New("build [directory]")
+	cmd.Args = cobra.ExactArgs(1)
 	cmd.Short = "build kubernetes api objects from a directory"
 
 	cmd.Flags().AddGoFlagSet(cfg.ClusterFlagSet())

--- a/internal/cli/render/render.go
+++ b/internal/cli/render/render.go
@@ -3,7 +3,6 @@ package render
 import (
 	"context"
 	"flag"
-	"fmt"
 	"runtime"
 
 	"github.com/holos-run/holos/internal/builder"
@@ -37,25 +36,12 @@ func NewComponent(cfg *holos.Config) *cobra.Command {
 	cmd.PersistentFlags().AddGoFlagSet(config.ClientFlagSet())
 	cmd.PersistentFlags().AddGoFlagSet(config.TokenFlagSet())
 
-	var printInstances bool
 	flagSet := flag.NewFlagSet("", flag.ContinueOnError)
-	flagSet.BoolVar(&printInstances, "print-instances", false, "expand /... paths for xargs")
 	cmd.Flags().AddGoFlagSet(flagSet)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Root().Context()
 		build := builder.New(builder.Entrypoints(args), builder.Cluster(cfg.ClusterName()))
-
-		if printInstances {
-			instances, err := build.Instances(ctx, config)
-			if err != nil {
-				return errors.Wrap(err)
-			}
-			for _, instance := range instances {
-				fmt.Fprintln(cmd.OutOrStdout(), instance.Dir)
-			}
-			return nil
-		}
 
 		results, err := build.Run(ctx, config)
 		if err != nil {


### PR DESCRIPTION
Now that we have multi-platform images, we need a way to easily deploy
them.  This involves changing the image tag.  kustomize edit is often
used to bump image tags, but we can do better providing it directly in
the unified CUE configuration.

This patch modifies the builder to unify user data *.json files
recursively under userdata/ into the #UserData definition of the holos
entrypoint.

This is to support automation that writes simple json files to version
control, executes holos render platform, then commits and pushes the
results for git ops to take over deployment.


Closes: #210
