### PR TITLE
docs: add httpbin routes section to expose a service guide

### DIFF
--- a/api/schema/v1alpha3/definitions.go
+++ b/api/schema/v1alpha3/definitions.go
@@ -147,6 +147,10 @@ type Platform struct {
 	// Output represents the core Platform spec for the holos cli to iterate over
 	// and render each listed Component, injecting the Model.
 	Output core.Platform
+	// Domain represents the primary domain the Platform operates in.  This field
+	// is intended as a sensible default for component authors to reference and
+	// platform operators to define.
+	Domain string `cue:"string | *\"holos.localhost\""`
 }
 
 // Kustomize provides a BuildPlan via the Output field which contains one

--- a/doc/md/api/schema/v1alpha3.md
+++ b/doc/md/api/schema/v1alpha3.md
@@ -185,6 +185,10 @@ type Platform struct {
     // Output represents the core Platform spec for the holos cli to iterate over
     // and render each listed Component, injecting the Model.
     Output core.Platform
+    // Domain represents the primary domain the Platform operates in.  This field
+    // is intended as a sensible default for component authors to reference and
+    // platform operators to define.
+    Domain string `cue:"string | *\"holos.localhost\""`
 }
 ```
 

--- a/doc/md/guides/expose-a-service.mdx
+++ b/doc/md/guides/expose-a-service.mdx
@@ -1347,8 +1347,81 @@ browse to it.  We'll add HTTPRoute and Certificate resources to expose the
 service.
 
 :::warning
-TODO
+TODO - Adding the routes should add the certificate!
 :::
+
+Generate the component.
+
+<Tabs groupId="gen-httpbin-routes">
+  <TabItem value="command" label="Command">
+```bash
+holos generate component httpbin-routes
+```
+  </TabItem>
+  <TabItem value="output" label="Output">
+```txt
+generated component
+```
+  </TabItem>
+</Tabs>
+
+:::warning
+REVIEW THE FILES
+:::
+
+Render the platform.
+
+<Tabs groupId="render-httpbin-routes">
+  <TabItem value="command" label="Command">
+```bash
+holos render platform ./platform
+```
+  </TabItem>
+  <TabItem value="output" label="Output">
+```txt showLineNumbers
+rendered components/httpbin/routes for cluster workload in 98.463125ms
+rendered components/httpbin/workload for cluster workload in 114.090583ms
+rendered components/istio/cni for cluster workload in 129.239125ms
+rendered components/istio/ztunnel for cluster workload in 131.220459ms
+rendered components/istio/gateway for cluster workload in 131.174834ms
+rendered components/istio/base for cluster workload in 131.630542ms
+rendered components/istio/istiod for cluster workload in 146.532083ms
+rendered components/cert-manager for cluster workload in 170.442625ms
+rendered components/local-ca for cluster workload in 77.9745ms
+rendered components/namespaces for cluster workload in 79.440166ms
+rendered components/gateway-api for cluster workload in 178.380917ms
+```
+  </TabItem>
+  <TabItem value="manifest" label="Manifest">
+  `deploy/clusters/workload/components/httpbin-routes/httpbin-routes.gen.yaml`
+```yaml showLineNumbers
+---
+# Source: CUE apiObjects.HTTPRoute.httpbin
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httpbin
+  namespace: istio-ingress
+  labels:
+    app: httpbin
+spec:
+  hostnames:
+    - httpbin.holos.localhost
+  parentRefs:
+    - name: default
+      namespace: istio-ingress
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: httpbin
+          namespace: httpbin
+          port: 80
+```
+  </TabItem>
+</Tabs>
 
 [Quickstart]: /docs/quickstart
 [Local Cluster]: /docs/guides/local-cluster

--- a/internal/generate/components/v1alpha3/httpbin-routes/components/httpbin/routes/httpbin-routes.cue
+++ b/internal/generate/components/v1alpha3/httpbin-routes/components/httpbin/routes/httpbin-routes.cue
@@ -1,0 +1,37 @@
+package holos
+
+// Produce a kubernetes objects build plan.
+(#Kubernetes & Objects).Output
+
+let Objects = {
+	Name:      "{{ .Name }}"
+	Namespace: #Istio.Gateway.Namespace
+
+	Resources: [_]: [_]: metadata: namespace: Namespace
+	Resources: HTTPRoute: (#HTTPRouteClone & {Name: "httpbin"}).Output
+}
+
+#HTTPRouteClone: {
+	Name: string
+	let Host = "\(Name).\(#Platform.Domain)"
+	Output: "\(Name)": {
+		metadata: namespace: _
+		metadata: name:      Name
+		metadata: labels: app: Name
+		spec: hostnames: [Host]
+		spec: parentRefs: [{
+			name:      "default"
+			namespace: metadata.namespace
+		}]
+		spec: rules: [
+			{
+				matches: [{path: {type: "PathPrefix", value: "/"}}]
+				backendRefs: [{
+					name:      Name
+					namespace: #HTTPBin.Namespace
+					port:      #HTTPBin.Port
+				}]
+			},
+		]
+	}
+}

--- a/internal/generate/components/v1alpha3/httpbin-routes/httpbin-routes.gen.cue
+++ b/internal/generate/components/v1alpha3/httpbin-routes/httpbin-routes.gen.cue
@@ -1,0 +1,9 @@
+package holos
+
+// Manage the component on workload clusters
+for Cluster in #Fleets.workload.clusters {
+	#Platform: Components: "\(Cluster.name)/{{ .Name }}": {
+		path:    "components/httpbin/routes"
+		cluster: Cluster.name
+	}
+}

--- a/internal/generate/components/v1alpha3/httpbin-routes/schematic.json
+++ b/internal/generate/components/v1alpha3/httpbin-routes/schematic.json
@@ -1,0 +1,6 @@
+{
+  "name": "httpbin-routes",
+  "short": "expose httpbin with httproute resources",
+  "long": "expose httpbin with httproute resources",
+  "namespace": "istio-ingress"
+}

--- a/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/schema/v1alpha3/definitions_go_gen.cue
+++ b/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/schema/v1alpha3/definitions_go_gen.cue
@@ -148,6 +148,11 @@ import (
 	// Output represents the core Platform spec for the holos cli to iterate over
 	// and render each listed Component, injecting the Model.
 	Output: core.#Platform
+
+	// Domain represents the primary domain the Platform operates in.  This field
+	// is intended as a sensible default for component authors to reference and
+	// platform operators to define.
+	Domain: string & (string | *"holos.localhost")
 }
 
 // Kustomize provides a BuildPlan via the Output field which contains one

--- a/internal/generate/platforms/cue.mod/pkg/github.com/holos-run/holos/api/schema/v1alpha3/definitions.cue
+++ b/internal/generate/platforms/cue.mod/pkg/github.com/holos-run/holos/api/schema/v1alpha3/definitions.cue
@@ -13,6 +13,8 @@ import (
 	app "argoproj.io/application/v1alpha1"
 	ci "cert-manager.io/clusterissuer/v1"
 	rgv1 "gateway.networking.k8s.io/referencegrant/v1beta1"
+	certv1 "cert-manager.io/certificate/v1"
+	hrv1 "gateway.networking.k8s.io/httproute/v1"
 )
 
 #Resources: {
@@ -21,12 +23,14 @@ import (
 		metadata: name: string | *InternalLabel
 	}
 
+	Certificate: [_]:        certv1.#Certificate
 	ClusterIssuer: [_]:      ci.#ClusterIssuer
 	ClusterRole: [_]:        rbacv1.#ClusterRole
 	ClusterRoleBinding: [_]: rbacv1.#ClusterRoleBinding
 	ConfigMap: [_]:          corev1.#ConfigMap
 	CronJob: [_]:            batchv1.#CronJob
 	Deployment: [_]:         appsv1.#Deployment
+	HTTPRoute: [_]:          hrv1.#HTTPRoute
 	Job: [_]:                batchv1.#Job
 	Namespace: [_]:          corev1.#Namespace
 	ReferenceGrant: [_]:     rgv1.#ReferenceGrant


### PR DESCRIPTION
This patch adds the httpbin routes component.  It's missing the
Certificate component, the next step is to wire up automatic certificate
management in the gateway configuration, which is a prime use case for
holos.  Similar to how we register components and namespaces, we'll
register certificates.

This patch also adds the #Platform.Domain field to the user facing
schema API.  We previously stored the domain in the Model but it makes
sense to lift it up to the Platform and have a sensible default value
for it.

Another example of #237 needing to be addressed soon.


Closes: #234
