### PR TITLE
api: move #Resources to package holos

### DIFF
--- a/doc/md/api/schema/v1alpha3.md
+++ b/doc/md/api/schema/v1alpha3.md
@@ -12,6 +12,7 @@ Package v1alpha3 contains CUE definitions intended as convenience wrappers aroun
 
 - [type ArgoConfig](<#ArgoConfig>)
 - [type Cluster](<#Cluster>)
+- [type ComponentFields](<#ComponentFields>)
 - [type Fleet](<#Fleet>)
 - [type Helm](<#Helm>)
 - [type Kubernetes](<#Kubernetes>)
@@ -62,6 +63,24 @@ type Cluster struct {
 }
 ```
 
+<a name="ComponentFields"></a>
+## type ComponentFields {#ComponentFields}
+
+Component represents the fields common the different kinds of component. All components have a name, support mixing in resources, and produce a BuildPlan.
+
+```go
+type ComponentFields struct {
+    // Name represents the Component name.
+    Name string
+    // Resources are kubernetes api objects to mix into the output.
+    Resources map[string]any
+    // ArgoConfig represents the ArgoCD GitOps configuration for this Component.
+    ArgoConfig ArgoConfig
+    // BuildPlan represents the derived BuildPlan for the Holos cli to render.
+    BuildPlan core.BuildPlan
+}
+```
+
 <a name="Fleet"></a>
 ## type Fleet {#Fleet}
 
@@ -82,14 +101,12 @@ Helm provides a BuildPlan via the Output field which contains one HelmChart from
 
 ```go
 type Helm struct {
-    // Name represents the Component name.
-    Name string
+    ComponentFields `json:",inline"`
+
     // Version represents the chart version.
     Version string
     // Namespace represents the helm namespace option when rendering the chart.
     Namespace string
-    // Resources are kubernetes api objects to mix into the output.
-    Resources map[string]any
 
     // Repo represents the chart repository
     Repo struct {
@@ -124,12 +141,6 @@ type Helm struct {
     // KustomizeResources represents additional resources files to include in the
     // kustomize resources list.
     KustomizeResources map[string]any `cue:"{[string]: {...}}"`
-
-    // ArgoConfig represents the ArgoCD GitOps configuration for this Component.
-    ArgoConfig ArgoConfig
-
-    // Output represents the derived BuildPlan for the Holos cli to render.
-    Output core.BuildPlan
 }
 ```
 
@@ -140,13 +151,9 @@ Kubernetes provides a BuildPlan via the Output field which contains inline API O
 
 ```go
 type Kubernetes struct {
-    // Name represents the Component name.
-    Name string
-    // Resources represents the kubernetes api objects for the Component.
-    Resources map[string]any
-
-    // Output represents the derived BuildPlan for the Holos cli to render.
-    Output core.BuildPlan
+    ComponentFields `json:",inline"`
+    // Objects represents the kubernetes api objects for the Component.
+    Objects core.KubernetesObjects
 }
 ```
 
@@ -157,14 +164,9 @@ Kustomize provides a BuildPlan via the Output field which contains one Kustomize
 
 ```go
 type Kustomize struct {
-    // Name represents the Component name.
-    Name string
-
+    ComponentFields `json:",inline"`
     // Kustomization represents the kustomize build plan for holos to render.
     Kustomization core.KustomizeBuild
-
-    // Output represents the derived BuildPlan for the Holos cli to render.
-    Output core.BuildPlan
 }
 ```
 

--- a/doc/md/guides/expose-a-service.mdx
+++ b/doc/md/guides/expose-a-service.mdx
@@ -704,7 +704,7 @@ the root.
 is not `"istio-system"`.  Future upgrades are safer with this constraint, if the
 upstream vendor changes the default in the future the component will fail
 validation.
-4. The root registers two Namespaces, `"istio-system"` and `"istio-ingress"`.
+4. The root registers the istio-system namespace with the namespaces component.
 5. The root manages the components on all workload clusters in the platform.
 
 <Tabs groupId="istio-files">

--- a/internal/generate/components/cue/argocd/argocd.cue
+++ b/internal/generate/components/cue/argocd/argocd.cue
@@ -1,4 +1,4 @@
 package holos
 
 // Produce a kubectl kustomize build plan.
-(#Kustomize & {Name: "{{ .Name }}"}).Output
+(#Kustomize & {Name: "{{ .Name }}"}).BuildPlan

--- a/internal/generate/components/cue/configmap/configmap.cue
+++ b/internal/generate/components/cue/configmap/configmap.cue
@@ -18,4 +18,4 @@ let Objects = {
 }
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan

--- a/internal/generate/components/cue/namespaces/namespaces.cue
+++ b/internal/generate/components/cue/namespaces/namespaces.cue
@@ -8,4 +8,4 @@ let Objects = {
 }
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan

--- a/internal/generate/components/helm/cert-manager/cert-manager.cue
+++ b/internal/generate/components/helm/cert-manager/cert-manager.cue
@@ -17,4 +17,4 @@ let Chart = {
 }
 
 // Produce a helm chart build plan.
-(#Helm & Chart).Output
+(#Helm & Chart).BuildPlan

--- a/internal/generate/components/helm/podinfo-oci/podinfo.cue
+++ b/internal/generate/components/helm/podinfo-oci/podinfo.cue
@@ -12,4 +12,4 @@ let Chart = {
 }
 
 // Produce a helm chart build plan.
-(#Helm & Chart).Output
+(#Helm & Chart).BuildPlan

--- a/internal/generate/components/v1alpha3/cert-manager/components/cert-manager/cert-manager.cue
+++ b/internal/generate/components/v1alpha3/cert-manager/components/cert-manager/cert-manager.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a helm chart build plan.
-(#Helm & Chart).Output
+(#Helm & Chart).BuildPlan
 
 let Chart = {
 	Name:      "{{ .Name }}"

--- a/internal/generate/components/v1alpha3/gateway-api/components/gateway-api/gateway-api.cue
+++ b/internal/generate/components/v1alpha3/gateway-api/components/gateway-api/gateway-api.cue
@@ -1,4 +1,4 @@
 package holos
 
 // Produce a kubectl kustomize build plan.
-(#Kustomize & {Name: "gateway-api"}).Output
+(#Kustomize & {Name: "gateway-api"}).BuildPlan

--- a/internal/generate/components/v1alpha3/httpbin-routes/components/httpbin/routes/httpbin-routes.cue
+++ b/internal/generate/components/v1alpha3/httpbin-routes/components/httpbin/routes/httpbin-routes.cue
@@ -1,14 +1,14 @@
 package holos
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 let Objects = {
 	Name:      "{{ .Name }}"
 	Namespace: #Istio.Gateway.Namespace
 
 	Resources: [_]: [_]: metadata: namespace: Namespace
-	Resources: HTTPRoute: (#HTTPRouteClone & {Name: "httpbin"}).Output
+	Resources: HTTPRoute: (#HTTPRouteClone & {Name: "httpbin"}).BuildPlan
 }
 
 #HTTPRouteClone: {

--- a/internal/generate/components/v1alpha3/httpbin-workload/components/httpbin/workload/httpbin-workload.cue
+++ b/internal/generate/components/v1alpha3/httpbin-workload/components/httpbin/workload/httpbin-workload.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 let Objects = {
 	Name:      "{{ .Name }}"

--- a/internal/generate/components/v1alpha3/istio-gateway/components/istio/gateway/gateway.cue
+++ b/internal/generate/components/v1alpha3/istio-gateway/components/istio/gateway/gateway.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 let Objects = {
 	Name:      "{{ .Name }}"

--- a/internal/generate/components/v1alpha3/istio/components/istio/base/istio-base.cue
+++ b/internal/generate/components/v1alpha3/istio/components/istio/base/istio-base.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a helm chart build plan.
-(#Helm & Chart).Output
+(#Helm & Chart).BuildPlan
 
 let Chart = {
 	Name:      "istio-base"

--- a/internal/generate/components/v1alpha3/istio/components/istio/cni/cni.cue
+++ b/internal/generate/components/v1alpha3/istio/components/istio/cni/cni.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a helm chart build plan.
-(#Helm & Chart).Output
+(#Helm & Chart).BuildPlan
 
 let Chart = {
 	Name:      "istio-cni"

--- a/internal/generate/components/v1alpha3/istio/components/istio/istiod/istiod.cue
+++ b/internal/generate/components/v1alpha3/istio/components/istio/istiod/istiod.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a helm chart build plan.
-(#Helm & Chart).Output
+(#Helm & Chart).BuildPlan
 
 let Chart = {
 	Name:      "istiod"

--- a/internal/generate/components/v1alpha3/istio/components/istio/ztunnel/ztunnel.cue
+++ b/internal/generate/components/v1alpha3/istio/components/istio/ztunnel/ztunnel.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a helm chart build plan.
-(#Helm & Chart).Output
+(#Helm & Chart).BuildPlan
 
 let Chart = {
 	Name:      "istio-ztunnel"

--- a/internal/generate/components/v1alpha3/local-ca/components/local-ca/local-ca.cue
+++ b/internal/generate/components/v1alpha3/local-ca/components/local-ca/local-ca.cue
@@ -3,7 +3,7 @@ package holos
 import ci "cert-manager.io/clusterissuer/v1"
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 let Objects = {
 	Name:      "local-ca"

--- a/internal/generate/components/v1alpha3/namespaces/components/namespaces/namespaces.cue
+++ b/internal/generate/components/v1alpha3/namespaces/components/namespaces/namespaces.cue
@@ -6,4 +6,4 @@ let Objects = {
 }
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan

--- a/internal/generate/components/v1alpha3/podinfo/components/podinfo/podinfo.gen.cue
+++ b/internal/generate/components/v1alpha3/podinfo/components/podinfo/podinfo.gen.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a helm chart build plan.
-(#Helm & Chart).Output
+(#Helm & Chart).BuildPlan
 
 let Chart = {
 	Name:      "{{ .Name }}"

--- a/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/schema/v1alpha3/definitions_go_gen.cue
+++ b/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/schema/v1alpha3/definitions_go_gen.cue
@@ -13,21 +13,33 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
+// Component represents the fields common the different kinds of component.  All
+// components have a name, support mixing in resources, and produce a BuildPlan.
+#ComponentFields: {
+	// Name represents the Component name.
+	Name: string
+
+	// Resources are kubernetes api objects to mix into the output.
+	Resources: {...} @go(,map[string]any)
+
+	// ArgoConfig represents the ArgoCD GitOps configuration for this Component.
+	ArgoConfig: #ArgoConfig
+
+	// BuildPlan represents the derived BuildPlan for the Holos cli to render.
+	BuildPlan: core.#BuildPlan
+}
+
 // Helm provides a BuildPlan via the Output field which contains one HelmChart
 // from package core.  Useful as a convenience wrapper to render a HelmChart
 // with optional mix-in resources and Kustomization post-processing.
 #Helm: {
-	// Name represents the Component name.
-	Name: string
+	#ComponentFields
 
 	// Version represents the chart version.
 	Version: string
 
 	// Namespace represents the helm namespace option when rendering the chart.
 	Namespace: string
-
-	// Resources are kubernetes api objects to mix into the output.
-	Resources: {...} @go(,map[string]any)
 
 	// Repo represents the chart repository
 	Repo: {
@@ -62,12 +74,24 @@ import (
 	// KustomizeResources represents additional resources files to include in the
 	// kustomize resources list.
 	KustomizeResources: {...} & {[string]: {...}} @go(,map[string]any)
+}
 
-	// ArgoConfig represents the ArgoCD GitOps configuration for this Component.
-	ArgoConfig: #ArgoConfig
+// Kustomize provides a BuildPlan via the Output field which contains one
+// KustomizeBuild from package core.
+#Kustomize: {
+	#ComponentFields
 
-	// Output represents the derived BuildPlan for the Holos cli to render.
-	Output: core.#BuildPlan
+	// Kustomization represents the kustomize build plan for holos to render.
+	Kustomization: core.#KustomizeBuild
+}
+
+// Kubernetes provides a BuildPlan via the Output field which contains inline
+// API Objects provided directly from CUE.
+#Kubernetes: {
+	#ComponentFields
+
+	// Objects represents the kubernetes api objects for the Component.
+	Objects: core.#KubernetesObjects
 }
 
 // ArgoConfig represents the ArgoCD GitOps configuration for a Component.
@@ -153,30 +177,4 @@ import (
 	// is intended as a sensible default for component authors to reference and
 	// platform operators to define.
 	Domain: string & (string | *"holos.localhost")
-}
-
-// Kustomize provides a BuildPlan via the Output field which contains one
-// KustomizeBuild from package core.
-#Kustomize: {
-	// Name represents the Component name.
-	Name: string
-
-	// Kustomization represents the kustomize build plan for holos to render.
-	Kustomization: core.#KustomizeBuild
-
-	// Output represents the derived BuildPlan for the Holos cli to render.
-	Output: core.#BuildPlan
-}
-
-// Kubernetes provides a BuildPlan via the Output field which contains inline
-// API Objects provided directly from CUE.
-#Kubernetes: {
-	// Name represents the Component name.
-	Name: string
-
-	// Resources represents the kubernetes api objects for the Component.
-	Resources: {...} @go(,map[string]any)
-
-	// Output represents the derived BuildPlan for the Holos cli to render.
-	Output: core.#BuildPlan
 }

--- a/internal/generate/platforms/cue.mod/pkg/github.com/holos-run/holos/api/core/v1alpha3/apiobjects.cue
+++ b/internal/generate/platforms/cue.mod/pkg/github.com/holos-run/holos/api/core/v1alpha3/apiobjects.cue
@@ -1,0 +1,16 @@
+package v1alpha3
+
+import "encoding/yaml"
+
+// #APIObjects defines the output format for kubernetes api objects.  The holos
+// cli expects the yaml representation of each api object in the apiObjectMap
+// field.
+#APIObjects: {
+	apiObjects: {...}
+
+	for kind, v in apiObjects {
+		for name, obj in v {
+			apiObjectMap: (kind): (name): yaml.Marshal(obj)
+		}
+	}
+}

--- a/internal/generate/platforms/cue.mod/pkg/github.com/holos-run/holos/api/v1alpha1/apiobjects.cue
+++ b/internal/generate/platforms/cue.mod/pkg/github.com/holos-run/holos/api/v1alpha1/apiobjects.cue
@@ -1,33 +1,12 @@
 package v1alpha1
 
-import "encoding/yaml"
-
-import core "k8s.io/api/core/v1"
-
 // #APIObjects defines the output format for kubernetes api objects.  The holos
 // cli expects the yaml representation of each api object in the apiObjectMap
 // field.
 #APIObjects: {
 	// apiObjects represents the un-marshalled form of each kubernetes api object
 	// managed by a holos component.
-	apiObjects: {
-		[Kind=string]: {
-			[string]: {
-				kind: Kind
-				...
-			}
-		}
-		ConfigMap: [string]: core.#ConfigMap & {apiVersion: "v1"}
-	}
-
+	apiObjects: [Kind=string]: [string]: kind: Kind
 	// apiObjectMap holds the marshalled representation of apiObjects
-	apiObjectMap: {
-		for kind, v in apiObjects {
-			"\(kind)": {
-				for name, obj in v {
-					"\(name)": yaml.Marshal(obj)
-				}
-			}
-		}
-	}
+	apiObjectsMap: [string]: [string]: string
 }

--- a/internal/generate/platforms/guide/resources.cue
+++ b/internal/generate/platforms/guide/resources.cue
@@ -1,0 +1,42 @@
+package holos
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	batchv1 "k8s.io/api/batch/v1"
+
+	ci "cert-manager.io/clusterissuer/v1"
+	rgv1 "gateway.networking.k8s.io/referencegrant/v1beta1"
+	certv1 "cert-manager.io/certificate/v1"
+	hrv1 "gateway.networking.k8s.io/httproute/v1"
+	gwv1 "gateway.networking.k8s.io/gateway/v1"
+)
+
+#Resources: {
+	[Kind=string]: [InternalLabel=string]: {
+		kind: Kind
+		metadata: name: string | *InternalLabel
+	}
+
+	Certificate: [_]:        certv1.#Certificate
+	ClusterIssuer: [_]:      ci.#ClusterIssuer
+	ClusterRole: [_]:        rbacv1.#ClusterRole
+	ClusterRoleBinding: [_]: rbacv1.#ClusterRoleBinding
+	ConfigMap: [_]:          corev1.#ConfigMap
+	CronJob: [_]:            batchv1.#CronJob
+	Deployment: [_]:         appsv1.#Deployment
+	HTTPRoute: [_]:          hrv1.#HTTPRoute
+	Job: [_]:                batchv1.#Job
+	Namespace: [_]:          corev1.#Namespace
+	ReferenceGrant: [_]:     rgv1.#ReferenceGrant
+	Role: [_]:               rbacv1.#Role
+	RoleBinding: [_]:        rbacv1.#RoleBinding
+	Service: [_]:            corev1.#Service
+	ServiceAccount: [_]:     corev1.#ServiceAccount
+	StatefulSet: [_]:        appsv1.#StatefulSet
+
+	Gateway: [_]: gwv1.#Gateway & {
+		spec: gatewayClassName: string | *"istio"
+	}
+}

--- a/internal/generate/platforms/guide/schema.gen.cue
+++ b/internal/generate/platforms/guide/schema.gen.cue
@@ -2,18 +2,18 @@ package holos
 
 import schema "github.com/holos-run/holos/api/schema/v1alpha3"
 
-#Helm: schema.#Helm & {
+#Platform: schema.#Platform
+#Fleets:   schema.#StandardFleets
+
+_ComponentConfig: {
+	Resources:  #Resources
 	ArgoConfig: #ArgoConfig
 }
 
-#Kustomize: schema.#Kustomize
-
-#Kubernetes: schema.#Kubernetes
+#Helm:       schema.#Helm & _ComponentConfig
+#Kustomize:  schema.#Kustomize & _ComponentConfig
+#Kubernetes: schema.#Kubernetes & _ComponentConfig
 
 #ArgoConfig: schema.#ArgoConfig & {
 	ClusterName: _ClusterName
 }
-
-#Fleets: schema.#StandardFleets
-
-#Platform: schema.#Platform

--- a/internal/generate/platforms/holos/apps/dev/holos/app/dev-holos-app.cue
+++ b/internal/generate/platforms/holos/apps/dev/holos/app/dev-holos-app.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 let Image = "quay.io/holos-run/holos:v0.83.1-7-gd9fe32b"
 

--- a/internal/generate/platforms/holos/apps/dev/holos/infra/dev-holos-infra.cue
+++ b/internal/generate/platforms/holos/apps/dev/holos/infra/dev-holos-infra.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 _AppInfo: spec: component: "infra"
 

--- a/internal/generate/platforms/holos/apps/dev/holos/routes/dev-holos-routes.cue
+++ b/internal/generate/platforms/holos/apps/dev/holos/routes/dev-holos-routes.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 _AppInfo: spec: component: "routes"
 

--- a/internal/generate/platforms/holos/components/argo/cd/argo-cd.cue
+++ b/internal/generate/platforms/holos/components/argo/cd/argo-cd.cue
@@ -6,7 +6,7 @@ import (
 )
 
 // Produce a helm chart build plan.
-(#Helm & Chart).Output
+(#Helm & Chart).BuildPlan
 
 let Chart = {
 	Name:      "argo-cd"

--- a/internal/generate/platforms/holos/components/argo/crds/argocd-crds.cue
+++ b/internal/generate/platforms/holos/components/argo/crds/argocd-crds.cue
@@ -1,4 +1,4 @@
 package holos
 
 // Produce a kubectl kustomize build plan.
-(#Kustomize & {Name: "argo-crds"}).Output
+(#Kustomize & {Name: "argo-crds"}).BuildPlan

--- a/internal/generate/platforms/holos/components/argo/creds/argo-creds.cue
+++ b/internal/generate/platforms/holos/components/argo/creds/argo-creds.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 let Objects = {
 	Name:      "argo-creds"

--- a/internal/generate/platforms/holos/components/argo/routes/argocd-routes.cue
+++ b/internal/generate/platforms/holos/components/argo/routes/argocd-routes.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 let Objects = {
 	Name:      "argocd-routes"

--- a/internal/generate/platforms/holos/components/backstage/management/certs/postgres-certs.cue
+++ b/internal/generate/platforms/holos/components/backstage/management/certs/postgres-certs.cue
@@ -14,7 +14,7 @@ import (
 // Refer to [Using Cert Manager to Deploy TLS for Postgres on Kubernetes](https://www.crunchydata.com/blog/using-cert-manager-to-deploy-tls-for-postgres-on-kubernetes)
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 let SelfSigned = "\(_DBName)-selfsigned"
 let RootCA = "\(_DBName)-root-ca"

--- a/internal/generate/platforms/holos/components/backstage/workload/backend/backstage-backend.cue
+++ b/internal/generate/platforms/holos/components/backstage/workload/backend/backstage-backend.cue
@@ -3,7 +3,7 @@ package holos
 import "encoding/yaml"
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 let ContainerPort = _Component.spec.port
 

--- a/internal/generate/platforms/holos/components/backstage/workload/database/postgres.cue
+++ b/internal/generate/platforms/holos/components/backstage/workload/database/postgres.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 // Restore from backup.  Flip this to true after the database is provisioned and
 // a backup has been taken.

--- a/internal/generate/platforms/holos/components/backstage/workload/routes/backstage-routes.cue
+++ b/internal/generate/platforms/holos/components/backstage/workload/routes/backstage-routes.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 let Objects = {
 	Name:      "\(_Component.metadata.name)-routes"

--- a/internal/generate/platforms/holos/components/backstage/workload/secrets/secrets.cue
+++ b/internal/generate/platforms/holos/components/backstage/workload/secrets/secrets.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 let Objects = {
 	Name:      "backstage-secrets"

--- a/internal/generate/platforms/holos/components/cert-letsencrypt/letsencrypt.cue
+++ b/internal/generate/platforms/holos/components/cert-letsencrypt/letsencrypt.cue
@@ -3,7 +3,7 @@ package holos
 import ci "cert-manager.io/clusterissuer/v1"
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 // The cloudflare api token is platform scoped, not cluster scoped.
 #SecretName: "cloudflare-api-token-secret"

--- a/internal/generate/platforms/holos/components/cert-manager/cert-manager.cue
+++ b/internal/generate/platforms/holos/components/cert-manager/cert-manager.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a helm chart build plan.
-(#Helm & Chart).Output
+(#Helm & Chart).BuildPlan
 
 let Chart = {
 	Name:      "cert-manager"

--- a/internal/generate/platforms/holos/components/certificates/certificates.cue
+++ b/internal/generate/platforms/holos/components/certificates/certificates.cue
@@ -8,4 +8,4 @@ let Objects = {
 }
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan

--- a/internal/generate/platforms/holos/components/crossplane/controller/crossplane.cue
+++ b/internal/generate/platforms/holos/components/crossplane/controller/crossplane.cue
@@ -8,7 +8,7 @@ import (
 )
 
 // Produce a helm chart build plan.
-(#Helm & Chart).Output
+(#Helm & Chart).BuildPlan
 
 // https://github.com/crossplane/crossplane/releases
 let CrossplaneVersion = "1.16.0"

--- a/internal/generate/platforms/holos/components/crossplane/crds/crossplane_crds.cue
+++ b/internal/generate/platforms/holos/components/crossplane/crds/crossplane_crds.cue
@@ -1,4 +1,4 @@
 package holos
 
 // Produce a kubectl kustomize build plan.
-(#Kustomize & {Name: "crossplane_crds"}).Output
+(#Kustomize & {Name: "crossplane_crds"}).BuildPlan

--- a/internal/generate/platforms/holos/components/ecr-creds-manager/ecr-creds-manager.cue
+++ b/internal/generate/platforms/holos/components/ecr-creds-manager/ecr-creds-manager.cue
@@ -9,7 +9,7 @@ import (
 let NAME = "ecr-creds-manager"
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 // The path Pod Identity uses.
 let MOUNT = "/var/run/secrets/eks.amazonaws.com/serviceaccount/"

--- a/internal/generate/platforms/holos/components/ecr-creds-refresher/ecr-creds-refresher.cue
+++ b/internal/generate/platforms/holos/components/ecr-creds-refresher/ecr-creds-refresher.cue
@@ -3,7 +3,7 @@ package holos
 let NAME = "ecr-creds-refresher"
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 let AWS_ACCOUNT = _Platform.Model.aws.accountNumber
 

--- a/internal/generate/platforms/holos/components/eks-pod-identity-webhook/eks-pod-identity-webhook.cue
+++ b/internal/generate/platforms/holos/components/eks-pod-identity-webhook/eks-pod-identity-webhook.cue
@@ -45,4 +45,4 @@ let Chart = {
 }
 
 // Produce a helm chart build plan.
-(#Helm & Chart).Output
+(#Helm & Chart).BuildPlan

--- a/internal/generate/platforms/holos/components/eso-creds-manager/eso-creds-manager.cue
+++ b/internal/generate/platforms/holos/components/eso-creds-manager/eso-creds-manager.cue
@@ -10,7 +10,7 @@ let REFRESHER = "eso-creds-refresher"
 let EMAIL = _Platform.Model.eso.gcpServiceAccount
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 let Objects = {
 	Name:      NAME

--- a/internal/generate/platforms/holos/components/eso-creds-refresher/eso-creds-refresher.cue
+++ b/internal/generate/platforms/holos/components/eso-creds-refresher/eso-creds-refresher.cue
@@ -10,7 +10,7 @@ import (
 let NAME = "eso-creds-refresher"
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 let Objects = {
 	Name:      NAME

--- a/internal/generate/platforms/holos/components/external-secrets/external-secrets.cue
+++ b/internal/generate/platforms/holos/components/external-secrets/external-secrets.cue
@@ -12,4 +12,4 @@ let Chart = {
 }
 
 // Produce a helm chart build plan.
-(#Helm & Chart).Output
+(#Helm & Chart).BuildPlan

--- a/internal/generate/platforms/holos/components/gateway-api/gateway-api.cue
+++ b/internal/generate/platforms/holos/components/gateway-api/gateway-api.cue
@@ -1,4 +1,4 @@
 package holos
 
 // Produce a kubectl kustomize build plan.
-(#Kustomize & {Name: "gateway-api"}).Output
+(#Kustomize & {Name: "gateway-api"}).BuildPlan

--- a/internal/generate/platforms/holos/components/istio/base/istio-base.cue
+++ b/internal/generate/platforms/holos/components/istio/base/istio-base.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a helm chart build plan.
-(#Helm & Chart).Output
+(#Helm & Chart).BuildPlan
 
 let Chart = {
 	Name:      "istio-base"

--- a/internal/generate/platforms/holos/components/istio/mesh/cni/cni.cue
+++ b/internal/generate/platforms/holos/components/istio/mesh/cni/cni.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a helm chart build plan.
-(#Helm & Chart).Output
+(#Helm & Chart).BuildPlan
 
 let Chart = {
 	Name:      "istio-cni"

--- a/internal/generate/platforms/holos/components/istio/mesh/gateway/gateways.cue
+++ b/internal/generate/platforms/holos/components/istio/mesh/gateway/gateways.cue
@@ -3,7 +3,7 @@ package holos
 import "encoding/json"
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 let Objects = {
 	Name:      "gateway"
@@ -42,10 +42,10 @@ let Objects = {
 			}
 			spec: {
 				// Work with a struct of listeners instead of a list.
-				_listeners: (#WildcardListener & {Name: "admin", Selector: _Selector.GrantSubdomainAdmin, Cluster: true}).Output
-				_listeners: (#WildcardListener & {Name: "login", Selector: _Selector.GrantSubdomainLogin, Cluster: false}).Output
-				_listeners: (#WildcardListener & {Name: "app", Selector: _Selector.GrantSubdomainApp, Cluster: false}).Output
-				_listeners: (#WildcardListener & {Name: "app", Selector: _Selector.GrantSubdomainApp, Cluster: true}).Output
+				_listeners: (#WildcardListener & {Name: "admin", Selector: _Selector.GrantSubdomainAdmin, Cluster: true}).BuildPlan
+				_listeners: (#WildcardListener & {Name: "login", Selector: _Selector.GrantSubdomainLogin, Cluster: false}).BuildPlan
+				_listeners: (#WildcardListener & {Name: "app", Selector: _Selector.GrantSubdomainApp, Cluster: false}).BuildPlan
+				_listeners: (#WildcardListener & {Name: "app", Selector: _Selector.GrantSubdomainApp, Cluster: true}).BuildPlan
 				listeners: [for x in _listeners {x}]
 			}
 		}

--- a/internal/generate/platforms/holos/components/istio/mesh/httpbin/backend/httpbin-backend.cue
+++ b/internal/generate/platforms/holos/components/istio/mesh/httpbin/backend/httpbin-backend.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 let Objects = {
 	Name:      "httpbin-backend"

--- a/internal/generate/platforms/holos/components/istio/mesh/httpbin/routes/httpbin-routes.cue
+++ b/internal/generate/platforms/holos/components/istio/mesh/httpbin/routes/httpbin-routes.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 let Objects = {
 	Name:      "httpbin-routes"
@@ -11,11 +11,11 @@ let Objects = {
 		Resources: [_]: [_]: metadata: namespace: Namespace
 		// Multiple HTTPRoutes to test Chrome http2 connection reuse with *.admin
 		// wildcard cert.
-		HTTPRoute: (#HTTPRouteClone & {Name: "httpbin"}).Output
-		HTTPRoute: (#HTTPRouteClone & {Name: "httpbin1"}).Output
-		HTTPRoute: (#HTTPRouteClone & {Name: "httpbin2"}).Output
-		HTTPRoute: (#HTTPRouteClone & {Name: "httpbin3"}).Output
-		HTTPRoute: (#HTTPRouteClone & {Name: "httpbin4"}).Output
+		HTTPRoute: (#HTTPRouteClone & {Name: "httpbin"}).BuildPlan
+		HTTPRoute: (#HTTPRouteClone & {Name: "httpbin1"}).BuildPlan
+		HTTPRoute: (#HTTPRouteClone & {Name: "httpbin2"}).BuildPlan
+		HTTPRoute: (#HTTPRouteClone & {Name: "httpbin3"}).BuildPlan
+		HTTPRoute: (#HTTPRouteClone & {Name: "httpbin4"}).BuildPlan
 	}
 }
 

--- a/internal/generate/platforms/holos/components/istio/mesh/iap/authpolicy/authpolicy.cue
+++ b/internal/generate/platforms/holos/components/istio/mesh/iap/authpolicy/authpolicy.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 let Objects = {
 	Name:      "authpolicy"

--- a/internal/generate/platforms/holos/components/istio/mesh/iap/authproxy/authproxy.cue
+++ b/internal/generate/platforms/holos/components/istio/mesh/iap/authproxy/authproxy.cue
@@ -3,7 +3,7 @@ package holos
 import "encoding/yaml"
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 let AuthProxyPrefix = _AuthProxy.pathPrefix
 

--- a/internal/generate/platforms/holos/components/istio/mesh/ingressgateway/ingressgateway.cue
+++ b/internal/generate/platforms/holos/components/istio/mesh/ingressgateway/ingressgateway.cue
@@ -3,7 +3,7 @@ package holos
 import "encoding/json"
 
 // Produce a helm chart build plan.
-(#Helm & Chart).Output
+(#Helm & Chart).BuildPlan
 
 let Chart = {
 	Name:      "gateway"

--- a/internal/generate/platforms/holos/components/istio/mesh/istiod/istiod.cue
+++ b/internal/generate/platforms/holos/components/istio/mesh/istiod/istiod.cue
@@ -3,9 +3,9 @@ package holos
 import "encoding/yaml"
 
 // Produce a helm chart build plan.
-(#Helm & Chart).Output
+(#Helm & Chart).BuildPlan
 
-_MeshConfig: (#MeshConfig & {}).Output
+_MeshConfig: (#MeshConfig & {}).BuildPlan
 
 let Chart = {
 	Name:      "istiod"

--- a/internal/generate/platforms/holos/components/login/zitadel-certs/postgres-certs.cue
+++ b/internal/generate/platforms/holos/components/login/zitadel-certs/postgres-certs.cue
@@ -14,7 +14,7 @@ import (
 // Refer to [Using Cert Manager to Deploy TLS for Postgres on Kubernetes](https://www.crunchydata.com/blog/using-cert-manager-to-deploy-tls-for-postgres-on-kubernetes)
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 let SelfSigned = "\(_DBName)-selfsigned"
 let RootCA = "\(_DBName)-root-ca"

--- a/internal/generate/platforms/holos/components/login/zitadel-database/postgres.cue
+++ b/internal/generate/platforms/holos/components/login/zitadel-database/postgres.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 // The Secret containing the pgbackrest s3.conf file has the same name as the S3
 // bucket the backups are sent to.

--- a/internal/generate/platforms/holos/components/login/zitadel-routes/zitadel-routes.cue
+++ b/internal/generate/platforms/holos/components/login/zitadel-routes/zitadel-routes.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 let Objects = {
 	Name:      "zitadel-routes"

--- a/internal/generate/platforms/holos/components/login/zitadel-secrets/zitadel-secrets.cue
+++ b/internal/generate/platforms/holos/components/login/zitadel-secrets/zitadel-secrets.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 let Objects = {
 	Name:      "zitadel-secrets"

--- a/internal/generate/platforms/holos/components/login/zitadel-server/zitadel.cue
+++ b/internal/generate/platforms/holos/components/login/zitadel-server/zitadel.cue
@@ -6,7 +6,7 @@ import (
 )
 
 // Produce a helm chart build plan.
-(#Helm & Chart).Output
+(#Helm & Chart).BuildPlan
 
 let Cluster = _Clusters[_ClusterName]
 

--- a/internal/generate/platforms/holos/components/namespaces/namespaces.cue
+++ b/internal/generate/platforms/holos/components/namespaces/namespaces.cue
@@ -8,4 +8,4 @@ let Objects = {
 }
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan

--- a/internal/generate/platforms/holos/components/pgo/controller/controller.cue
+++ b/internal/generate/platforms/holos/components/pgo/controller/controller.cue
@@ -1,4 +1,4 @@
 package holos
 
 // Produce a kubectl kustomize build plan.
-(#Kustomize & {Name: "postgres-operator"}).Output
+(#Kustomize & {Name: "postgres-operator"}).BuildPlan

--- a/internal/generate/platforms/holos/components/pgo/crds/pgocrds.cue
+++ b/internal/generate/platforms/holos/components/pgo/crds/pgocrds.cue
@@ -1,4 +1,4 @@
 package holos
 
 // Produce a kubectl kustomize build plan.
-(#Kustomize & {Name: "postgres-crds"}).Output
+(#Kustomize & {Name: "postgres-crds"}).BuildPlan

--- a/internal/generate/platforms/holos/components/secretstores/secretstores.cue
+++ b/internal/generate/platforms/holos/components/secretstores/secretstores.cue
@@ -3,7 +3,7 @@ package holos
 import ss "external-secrets.io/secretstore/v1beta1"
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 let Objects = {
 	Name:      "secretstores"

--- a/internal/generate/platforms/k3d/components/argo/authpolicy/authpolicy.cue
+++ b/internal/generate/platforms/k3d/components/argo/authpolicy/authpolicy.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 let Objects = {
 	Name:      "argo-authpolicy"

--- a/internal/generate/platforms/k3d/components/argo/cd/argo-cd.cue
+++ b/internal/generate/platforms/k3d/components/argo/cd/argo-cd.cue
@@ -6,7 +6,7 @@ import (
 )
 
 // Produce a helm chart build plan.
-(#Helm & Chart).Output
+(#Helm & Chart).BuildPlan
 
 let Chart = {
 	Name:      "argo-cd"

--- a/internal/generate/platforms/k3d/components/argo/crds/argocd-crds.cue
+++ b/internal/generate/platforms/k3d/components/argo/crds/argocd-crds.cue
@@ -1,4 +1,4 @@
 package holos
 
 // Produce a kubectl kustomize build plan.
-(#Kustomize & {Name: "argo-crds"}).Output
+(#Kustomize & {Name: "argo-crds"}).BuildPlan

--- a/internal/generate/platforms/k3d/components/argo/creds/argo-creds.cue
+++ b/internal/generate/platforms/k3d/components/argo/creds/argo-creds.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 let Objects = {
 	Name:      "argo-creds"

--- a/internal/generate/platforms/k3d/components/argo/routes/argocd-routes.cue
+++ b/internal/generate/platforms/k3d/components/argo/routes/argocd-routes.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 let Objects = {
 	Name:      "argo-routes"

--- a/internal/generate/platforms/k3d/components/cert-local-ca/local-ca.cue
+++ b/internal/generate/platforms/k3d/components/cert-local-ca/local-ca.cue
@@ -3,7 +3,7 @@ package holos
 import ci "cert-manager.io/clusterissuer/v1"
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 let Objects = {
 	Name:      "local-ca"

--- a/internal/generate/platforms/k3d/components/cert-manager/cert-manager.cue
+++ b/internal/generate/platforms/k3d/components/cert-manager/cert-manager.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a helm chart build plan.
-(#Helm & Chart).Output
+(#Helm & Chart).BuildPlan
 
 let Chart = {
 	Name:      "cert-manager"

--- a/internal/generate/platforms/k3d/components/certificates/certificates.cue
+++ b/internal/generate/platforms/k3d/components/certificates/certificates.cue
@@ -27,4 +27,4 @@ let Objects = {
 }
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan

--- a/internal/generate/platforms/k3d/components/gateway-api/gateway-api.cue
+++ b/internal/generate/platforms/k3d/components/gateway-api/gateway-api.cue
@@ -1,4 +1,4 @@
 package holos
 
 // Produce a kubectl kustomize build plan.
-(#Kustomize & {Name: "gateway-api"}).Output
+(#Kustomize & {Name: "gateway-api"}).BuildPlan

--- a/internal/generate/platforms/k3d/components/istio/base/istio-base.cue
+++ b/internal/generate/platforms/k3d/components/istio/base/istio-base.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a helm chart build plan.
-(#Helm & Chart).Output
+(#Helm & Chart).BuildPlan
 
 let Chart = {
 	Name:      "istio-base"

--- a/internal/generate/platforms/k3d/components/istio/mesh/cni/cni.cue
+++ b/internal/generate/platforms/k3d/components/istio/mesh/cni/cni.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a helm chart build plan.
-(#Helm & Chart).Output
+(#Helm & Chart).BuildPlan
 
 let Chart = {
 	Name:      "istio-cni"

--- a/internal/generate/platforms/k3d/components/istio/mesh/gateway/gateways.cue
+++ b/internal/generate/platforms/k3d/components/istio/mesh/gateway/gateways.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 let Objects = {
 	Name:      "gateway"
@@ -23,10 +23,10 @@ let Objects = {
 			metadata: namespace: Namespace
 			spec: {
 				// Work with a struct of listeners instead of a list.
-				_listeners: (#WildcardListener & {Name: "httpbin", Cluster: false}).Output
-				_listeners: (#WildcardListener & {Name: "argocd", Cluster: false}).Output
-				_listeners: (#WildcardListener & {Name: "backstage", Cluster: false}).Output
-				_listeners: (#WildcardListener & {Name: "app", Cluster: false}).Output
+				_listeners: (#WildcardListener & {Name: "httpbin", Cluster: false}).BuildPlan
+				_listeners: (#WildcardListener & {Name: "argocd", Cluster: false}).BuildPlan
+				_listeners: (#WildcardListener & {Name: "backstage", Cluster: false}).BuildPlan
+				_listeners: (#WildcardListener & {Name: "app", Cluster: false}).BuildPlan
 				listeners: [for x in _listeners {x}]
 			}
 		}

--- a/internal/generate/platforms/k3d/components/istio/mesh/httpbin/backend/httpbin-backend.cue
+++ b/internal/generate/platforms/k3d/components/istio/mesh/httpbin/backend/httpbin-backend.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 let Objects = {
 	Name:      "httpbin-backend"

--- a/internal/generate/platforms/k3d/components/istio/mesh/httpbin/routes/httpbin-routes.cue
+++ b/internal/generate/platforms/k3d/components/istio/mesh/httpbin/routes/httpbin-routes.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 let Objects = {
 	Name:      "httpbin-routes"
@@ -9,7 +9,7 @@ let Objects = {
 
 	Resources: {
 		Resources: [_]: [_]: metadata: namespace: Namespace
-		HTTPRoute: (#HTTPRouteClone & {Name: "httpbin"}).Output
+		HTTPRoute: (#HTTPRouteClone & {Name: "httpbin"}).BuildPlan
 	}
 }
 

--- a/internal/generate/platforms/k3d/components/istio/mesh/iap/authpolicy/authpolicy.cue
+++ b/internal/generate/platforms/k3d/components/istio/mesh/iap/authpolicy/authpolicy.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 let Mode = _Platform.Model.rbac.mode
 

--- a/internal/generate/platforms/k3d/components/istio/mesh/iap/authproxy/authproxy.cue
+++ b/internal/generate/platforms/k3d/components/istio/mesh/iap/authproxy/authproxy.cue
@@ -3,7 +3,7 @@ package holos
 import "encoding/yaml"
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 let AuthProxyPrefix = _AuthProxy.pathPrefix
 

--- a/internal/generate/platforms/k3d/components/istio/mesh/iap/authroutes/authroutes.cue
+++ b/internal/generate/platforms/k3d/components/istio/mesh/iap/authroutes/authroutes.cue
@@ -1,7 +1,7 @@
 package holos
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan
 
 let Objects = {
 	Name:      "authroutes"
@@ -9,7 +9,7 @@ let Objects = {
 
 	Resources: {
 		Resources: [_]: [_]: metadata: namespace: Namespace
-		HTTPRoute: (#HTTPRouteClone & {Name: "authproxy"}).Output
+		HTTPRoute: (#HTTPRouteClone & {Name: "authproxy"}).BuildPlan
 	}
 }
 

--- a/internal/generate/platforms/k3d/components/istio/mesh/ingressgateway/ingressgateway.cue
+++ b/internal/generate/platforms/k3d/components/istio/mesh/ingressgateway/ingressgateway.cue
@@ -3,7 +3,7 @@ package holos
 import "encoding/json"
 
 // Produce a helm chart build plan.
-(#Helm & Chart).Output
+(#Helm & Chart).BuildPlan
 
 let Chart = {
 	Name:      "gateway"

--- a/internal/generate/platforms/k3d/components/istio/mesh/istiod/istiod.cue
+++ b/internal/generate/platforms/k3d/components/istio/mesh/istiod/istiod.cue
@@ -3,9 +3,9 @@ package holos
 import "encoding/yaml"
 
 // Produce a helm chart build plan.
-(#Helm & Chart).Output
+(#Helm & Chart).BuildPlan
 
-_MeshConfig: (#MeshConfig & {}).Output
+_MeshConfig: (#MeshConfig & {}).BuildPlan
 
 let Chart = {
 	Name:      "istiod"

--- a/internal/generate/platforms/k3d/components/namespaces/namespaces.cue
+++ b/internal/generate/platforms/k3d/components/namespaces/namespaces.cue
@@ -8,4 +8,4 @@ let Objects = {
 }
 
 // Produce a kubernetes objects build plan.
-(#Kubernetes & Objects).Output
+(#Kubernetes & Objects).BuildPlan

--- a/internal/generate/platforms/k3d/components/pgo/controller/controller.cue
+++ b/internal/generate/platforms/k3d/components/pgo/controller/controller.cue
@@ -1,4 +1,4 @@
 package holos
 
 // Produce a kubectl kustomize build plan.
-(#Kustomize & {Name: "postgres-operator"}).Output
+(#Kustomize & {Name: "postgres-operator"}).BuildPlan

--- a/internal/generate/platforms/k3d/components/pgo/crds/pgocrds.cue
+++ b/internal/generate/platforms/k3d/components/pgo/crds/pgocrds.cue
@@ -1,4 +1,4 @@
 package holos
 
 // Produce a kubectl kustomize build plan.
-(#Kustomize & {Name: "postgres-crds"}).Output
+(#Kustomize & {Name: "postgres-crds"}).BuildPlan


### PR DESCRIPTION
Previously, the #Resources struct listing valid resources to use with
APIObjects in each of the components types was closed.  This made it
very difficult for users to mix in new resources and use the Kubernetes
component kind.

This patch moves the definition of the valid resources to package holos
from the schema API.  The schema still enforces some light constraints,
but doesn't keep the struct closed.

A new convention is introduced in the form of configuring all components
using _ComponentConfig defined at the root, then unifying this struct
with all of the component kinds.  See schema.gen.cue for how this works.

This approach enables mixing in ArgoCD applications to all component
kinds, not just Helm as was done previously.  Similarly, the
user-constrained #Resources definition unifies with all component kinds.

It's OK to leave the yaml.Marshall in the schema API.  The user
shouldn't ever have to deal with #APIObjects, instead they should pass
Resources through the schema API which will use APIObjects to create
apiObjectMap for each component type and the BuildPlan.

This is still more awkward than I want, but it's a good step in the
right direction.


Closes: #237
