### PR TITLE
Make the landing page more concise

### DIFF
--- a/doc/website/docusaurus.config.ts
+++ b/doc/website/docusaurus.config.ts
@@ -4,7 +4,7 @@ import type * as Preset from '@docusaurus/preset-classic';
 
 const config: Config = {
   title: 'Holos',
-  tagline: 'Holos makes it easier for platform teams to integrate software into their platform.',
+  tagline: 'An easier way for platform teams to integrate software into their platform',
   favicon: 'img/favicon.ico',
 
   // Set the production url of your site here

--- a/doc/website/src/components/HomepageFeatures/index.tsx
+++ b/doc/website/src/components/HomepageFeatures/index.tsx
@@ -15,13 +15,14 @@ const FeatureList: FeatureItem[] = [
     Svg: require('@site/static/img/base00/undraw_software_engineer_re_tnjc.svg').default,
     description: (
       <>
-        Focus on building platform features, not maintaining scripts and
-        templates. Add type checking to Helm charts and manifests. Define golden
-        paths for teams to launch projects independently. Automatically manage
-        Namespaces, Certificates, Secrets, and Roles with CUE. Use upstream
-        charts and mix in resources that make your platform unique.
-        <br />
-        <a href="/docs/">Learn More</a>
+        <p align="left">
+          <ul>
+            <li>Provide simple definitions for other teams to use as golden paths.</li>
+            <li>Define integrations in <a href="https://cuelang.org/">CUE</a> with strong type checking. No more text templates or bash scripts.</li>
+            <li>Reuse your existing Helm charts and Kustomize bases.</li>
+          </ul>
+        </p>
+        <a href="/docs/technical-overview">Learn More</a>
       </>
     ),
   },
@@ -30,13 +31,14 @@ const FeatureList: FeatureItem[] = [
     Svg: require('@site/static/img/base00/undraw_through_the_park_lxnl.svg').default,
     description: (
       <>
-        Move faster with paved paths from your platform and security teams. Spin
-        up new projects and environments without tickets. Develop locally or in
-        the cloud. Deploy Helm charts, Kubernetes manifests, or containers
-        confidently with type checking. Reduce friction when integrating
-        services into your organization's platform.
-        <br />
-        <a href="/docs/">Learn More</a>
+        <p align="left">
+          <ul>
+            <li>Move faster using paved paths from your platform and security teams.</li>
+            <li>Develop locally or in the cloud.</li>
+            <li>Spend more time developing software and fewer cycles fighting infrastructure challenges.</li>
+          </ul>
+        </p>
+        <a href="/docs/technical-overview">Learn More</a>
       </>
     ),
   },
@@ -45,13 +47,14 @@ const FeatureList: FeatureItem[] = [
     Svg: require('@site/static/img/base00/undraw_security_on_re_e491.svg').default,
     description: (
       <>
-        Define security policies as reusable, typed configurations.
-        Automatically apply the policy to new projects. Build guardrails for
-        secure service development. Get clear visibility into the platform's
-        configuration to quickly identify risks and audit security posture.
-        Integrate your preferred security tools seamlessly with the platform.
-        <br />
-        <a href="/docs/">Learn More</a>
+        <p align="left">
+          <ul>
+            <li>Define security policy as reusable, typed configurations.</li>
+            <li>Automatically enforce security policy on new projects.</li>
+            <li>Ensure a consistent security posture cross-platform with fewer code changes.</li>
+          </ul>
+        </p>
+        <a href="/docs/technical-overview">Learn More</a>
       </>
     ),
   }

--- a/doc/website/src/css/custom.css
+++ b/doc/website/src/css/custom.css
@@ -22,6 +22,10 @@
   text-align: left;
 }
 
+.hero__buttons {
+  float: left
+}
+
 /* Ensure img in hero banner scales well even on mobile */
 @media screen and (max-width: 996px) {
   div.diagramImg {

--- a/doc/website/src/pages/index.tsx
+++ b/doc/website/src/pages/index.tsx
@@ -12,37 +12,28 @@ function HomepageHeader() {
   return (
     <header className={clsx('hero hero--primary', styles.heroBanner)}>
       <div className="container">
-        <Heading as="h1" className="hero__title">
-          {siteConfig.title}
-        </Heading>
         <div className="diagramImg">
           <img src="./img/holos-diagram-color-transparent.svg" alt="Holos Diagram" />
         </div>
+        <Heading as="h1" className="hero__title">
+          {siteConfig.title}
+        </Heading>
         <p className="hero__subtitle">{siteConfig.tagline}</p>
-        <p className="projectDesc">
-          Engineering teams spend significant time creating custom scripts and
-          error-prone templates to integrate software projects into a software
-          development platform.  This glue layer is often makeshift, slowing
-          teams down and increasing the risk of outages.
-        </p>
-        <p className="projectDesc">
-          Holos helps teams deliver value faster by offering a well defined,
-          safe, and automated integration layer to manage your platform
-          holistically.
-        </p>
-        <div className={styles.buttons}>
-          <Link
-            className="button button--secondary button--lg"
-            to="docs/quickstart">
-            Get Started
-          </Link>
-          <span className={styles.divider}></span>
-          <Link
-            className="button button--primary button--lg"
-            to="docs/technical-overview/">
-            Learn More
-          </Link>
-          <span className={styles.divider}></span>
+        <div className="hero__buttons">
+          <div className={styles.buttons}>
+            <Link
+              className="button button--secondary button--lg"
+              to="docs/quickstart">
+              Get Started
+            </Link>
+            <span className={styles.divider}></span>
+            <Link
+              className="button button--primary button--lg"
+              to="docs/technical-overview/">
+              Learn More
+            </Link>
+            <span className={styles.divider}></span>
+            </div>
         </div>
       </div >
     </header >


### PR DESCRIPTION
PROBLEM:

The landing page contains a lot of text, and much of that text was
written before we refined our messaging within the guides and technical
overview pages.

SOLUTION:

* Whittle down landing page text to only the key messages we want to convey.
* Provide messaging bullets for the features.
* Steer folks (via links) to the quickstart guide or technical overview document.

OUTCOME:

Visitors don't need to wade through a lot of text to receive key
messaging talking points or links to the pages they should read.