### PR TITLE
v1alpha4: add concurrent build plan artifacts

### DIFF
--- a/api/core/v1alpha4/types.go
+++ b/api/core/v1alpha4/types.go
@@ -47,10 +47,6 @@ type BuildPlanSpec struct {
 // sequence, which transforms a [Generator] collection.  A [BuildPlan] produces
 // an [Artifact] collection.
 //
-// Each [Generator] may be executed concurrently with other generators in the
-// same collection. Each [Transformer] is executed sequentially, the first after
-// all generators have completed.
-//
 // Each Artifact produces one manifest file artifact.  Generator Output values
 // are used as Transformer Inputs.  The Output field of the final [Transformer]
 // should have the same value as the Artifact field.
@@ -59,8 +55,13 @@ type BuildPlanSpec struct {
 // [Transformer] to combine outputs into one Artifact.  If there is a single
 // Generator, it may directly produce the Artifact output.
 //
+// An Artifact is processed concurrently with other artifacts in the same
+// [BuildPlan].  An Artifact should not use an output from another Artifact as
+// an input.  Each [Generator] may also run concurrently.  Each [Transformer] is
+// executed sequentially starting after all generators have completed.
+//
 // Output fields are write-once.  It is an error for multiple Generators or
-// Transformers to produce the same Output value within the context of one
+// Transformers to produce the same Output value within the context of a
 // [BuildPlan].
 type Artifact struct {
 	Artifact     FilePath      `json:"artifact,omitempty"`

--- a/doc/md/api/core/v1alpha4.md
+++ b/doc/md/api/core/v1alpha4.md
@@ -46,13 +46,13 @@ Each holos component path, e.g. \`components/namespaces\` produces exactly one [
 
 Artifact represents one fully rendered manifest produced by a [Transformer](<#Transformer>) sequence, which transforms a [Generator](<#Generator>) collection. A [BuildPlan](<#BuildPlan>) produces an [Artifact](<#Artifact>) collection.
 
-Each [Generator](<#Generator>) may be executed concurrently with other generators in the same collection. Each [Transformer](<#Transformer>) is executed sequentially, the first after all generators have completed.
-
 Each Artifact produces one manifest file artifact. Generator Output values are used as Transformer Inputs. The Output field of the final [Transformer](<#Transformer>) should have the same value as the Artifact field.
 
 When there is more than one [Generator](<#Generator>) there must be at least one [Transformer](<#Transformer>) to combine outputs into one Artifact. If there is a single Generator, it may directly produce the Artifact output.
 
-Output fields are write\-once. It is an error for multiple Generators or Transformers to produce the same Output value within the context of one [BuildPlan](<#BuildPlan>).
+An Artifact is processed concurrently with other artifacts in the same [BuildPlan](<#BuildPlan>). An Artifact should not use an output from another Artifact as an input. Each [Generator](<#Generator>) may also run concurrently. Each [Transformer](<#Transformer>) is executed sequentially starting after all generators have completed.
+
+Output fields are write\-once. It is an error for multiple Generators or Transformers to produce the same Output value within the context of a [BuildPlan](<#BuildPlan>).
 
 ```go
 type Artifact struct {

--- a/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/core/v1alpha4/types_go_gen.cue
+++ b/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/core/v1alpha4/types_go_gen.cue
@@ -54,10 +54,6 @@ package v1alpha4
 // sequence, which transforms a [Generator] collection.  A [BuildPlan] produces
 // an [Artifact] collection.
 //
-// Each [Generator] may be executed concurrently with other generators in the
-// same collection. Each [Transformer] is executed sequentially, the first after
-// all generators have completed.
-//
 // Each Artifact produces one manifest file artifact.  Generator Output values
 // are used as Transformer Inputs.  The Output field of the final [Transformer]
 // should have the same value as the Artifact field.
@@ -66,8 +62,13 @@ package v1alpha4
 // [Transformer] to combine outputs into one Artifact.  If there is a single
 // Generator, it may directly produce the Artifact output.
 //
+// An Artifact is processed concurrently with other artifacts in the same
+// [BuildPlan].  An Artifact should not use an output from another Artifact as
+// an input.  Each [Generator] may also run concurrently.  Each [Transformer] is
+// executed sequentially starting after all generators have completed.
+//
 // Output fields are write-once.  It is an error for multiple Generators or
-// Transformers to produce the same Output value within the context of one
+// Transformers to produce the same Output value within the context of a
 // [BuildPlan].
 #Artifact: {
 	artifact?: #FilePath @go(Artifact)


### PR DESCRIPTION
Previously the Artifact collection was processed sequentially.  This
patch provides a modest performance improvement, about 16% faster for
our simple 2 artifact use case, by processing each artifact
concurrently.
