### PR TITLE
v1alpha4: add join transformer

### DIFF
--- a/api/core/v1alpha4/types.go
+++ b/api/core/v1alpha4/types.go
@@ -161,7 +161,7 @@ type Transformer struct {
 // Useful for the common case of combining the output of [Helm] and [Resources]
 // [Generator] into one [Artifact] when [Kustomize] is otherwise unnecessary.
 type Join struct {
-	Separator string `json:"separator,omitempty"`
+	Separator string `json:"separator" cue:"string | *\"---\\n\""`
 }
 
 // Kustomize represents a kustomization [Transformer].

--- a/doc/md/api/core/v1alpha4.md
+++ b/doc/md/api/core/v1alpha4.md
@@ -248,7 +248,7 @@ Join represents a [Join](<#Join>)\(https://pkg.go.dev/strings#Join\) [Transforme
 
 ```go
 type Join struct {
-    Separator string `json:"separator,omitempty"`
+    Separator string `json:"separator" cue:"string | *\"---\\n\""`
 }
 ```
 

--- a/holos.go
+++ b/holos.go
@@ -36,6 +36,7 @@ type Builder interface {
 // FilePath was previously Set.  Concrete values must be safe for concurrent
 // reads and writes.
 type ArtifactMap interface {
-	Get(FilePath) ([]byte, bool)
-	Set(FilePath, []byte) error
+	Get(path FilePath) (data []byte, ok bool)
+	Set(path FilePath, data []byte) error
+	Save(dir, path FilePath) error
 }

--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -48,7 +48,7 @@ func (a *Artifact) Save(dir, path holos.FilePath) error {
 	msg := fmt.Sprintf("could not save %s", fullPath)
 	data, ok := a.Get(path)
 	if !ok {
-		return errors.Format("%s: could not get: not set: %s", msg, path)
+		return errors.Format("%s: could not get %s: not set", msg, path)
 	}
 	if err := os.MkdirAll(filepath.Dir(fullPath), 0777); err != nil {
 		return errors.Format("%s: %w", msg, err)

--- a/internal/builder/v1alpha4/builder.go
+++ b/internal/builder/v1alpha4/builder.go
@@ -172,7 +172,19 @@ func (b *BuildPlan) Build(ctx context.Context, am h.ArtifactMap) error {
 								return errors.Wrap(err)
 							}
 						case "Join":
-							return errors.NotImplemented()
+							s := make([][]byte, 0, len(t.Inputs))
+							for _, input := range t.Inputs {
+								if data, ok := am.Get(h.FilePath(input)); ok {
+									s = append(s, data)
+								} else {
+									return errors.Format("%s: could not get %s: not set", msg, input)
+								}
+							}
+							data := bytes.Join(s, []byte(t.Join.Separator))
+							if err := am.Set(h.FilePath(t.Output), data); err != nil {
+								return errors.Format("%s: %w", msg, err)
+							}
+							log.Debug("set artifact: " + string(t.Output))
 						default:
 							return errors.Format("%s: %s kind not supported", msg, t.Kind)
 						}

--- a/internal/builder/v1alpha4/builder.go
+++ b/internal/builder/v1alpha4/builder.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/holos-run/holos"
+	h "github.com/holos-run/holos"
 	"github.com/holos-run/holos/api/core/v1alpha4"
 	"github.com/holos-run/holos/internal/errors"
 	"github.com/holos-run/holos/internal/logger"
@@ -30,7 +30,7 @@ type Platform struct {
 // Build builds a Platform by concurrently building a BuildPlan for each
 // platform component.  No artifact files are written directly, only indirectly
 // by rendering each component.
-func (p *Platform) Build(ctx context.Context, _ holos.ArtifactMap) error {
+func (p *Platform) Build(ctx context.Context, _ h.ArtifactMap) error {
 	parentStart := time.Now()
 	components := p.Platform.Spec.Components
 	total := len(components)
@@ -121,7 +121,7 @@ type BuildPlan struct {
 }
 
 // Build builds a BuildPlan into Artifact files.
-func (b *BuildPlan) Build(ctx context.Context, am holos.ArtifactMap) error {
+func (b *BuildPlan) Build(ctx context.Context, am h.ArtifactMap) error {
 	name := b.BuildPlan.Metadata.Name
 	component := b.BuildPlan.Spec.Component
 	log := logger.FromContext(ctx).With("name", name, "component", component)
@@ -150,10 +150,10 @@ func (b *BuildPlan) Build(ctx context.Context, am holos.ArtifactMap) error {
 				a := a
 				// Worker.  Blocks if limit has been reached.
 				g.Go(func() error {
-					for _, g := range a.Generators {
-						switch g.Kind {
+					for _, gen := range a.Generators {
+						switch gen.Kind {
 						case "Resources":
-							if err := b.generateResources(log, g, am); err != nil {
+							if err := b.generateResources(log, gen, am); err != nil {
 								return errors.Wrap(err)
 							}
 						case "Helm":
@@ -161,7 +161,7 @@ func (b *BuildPlan) Build(ctx context.Context, am holos.ArtifactMap) error {
 						case "File":
 							return errors.NotImplemented()
 						default:
-							return errors.Format("%s: unsupported kind %s", msg, g.Kind)
+							return errors.Format("%s: %s kind not supported", msg, gen.Kind)
 						}
 					}
 
@@ -174,23 +174,16 @@ func (b *BuildPlan) Build(ctx context.Context, am holos.ArtifactMap) error {
 						case "Join":
 							return errors.NotImplemented()
 						default:
-							return errors.Format("%s: unsupported kind %s", msg, t.Kind)
+							return errors.Format("%s: %s kind not supported", msg, t.Kind)
 						}
 					}
 
 					// Write the final artifact
-					data, ok := am.Get(holos.FilePath(a.Artifact))
-					if !ok {
-						return errors.Format("%s: could not get artifact %s", msg, a.Artifact)
-					}
-					path := filepath.Join(b.WriteTo, string(a.Artifact))
-					if err := os.MkdirAll(filepath.Dir(path), 0777); err != nil {
+					if err := am.Save(h.FilePath(b.WriteTo), h.FilePath(a.Artifact)); err != nil {
 						return errors.Format("%s: %w", msg, err)
 					}
-					if err := os.WriteFile(path, data, 0666); err != nil {
-						return errors.Format("%s: %w", msg, err)
-					}
-					log.DebugContext(ctx, "wrote: "+path)
+					log.DebugContext(ctx, "wrote: "+filepath.Join(b.WriteTo, string(a.Artifact)))
+
 					return nil
 				})
 			}
@@ -205,7 +198,7 @@ func (b *BuildPlan) Build(ctx context.Context, am holos.ArtifactMap) error {
 func (b *BuildPlan) generateResources(
 	log *slog.Logger,
 	g v1alpha4.Generator,
-	am holos.ArtifactMap,
+	am h.ArtifactMap,
 ) error {
 	var size int
 	for _, m := range g.Resources {
@@ -226,7 +219,7 @@ func (b *BuildPlan) generateResources(
 		return errors.Format("%s: %w", msg, err)
 	}
 
-	if err := am.Set(holos.FilePath(g.Output), buf.Bytes()); err != nil {
+	if err := am.Set(h.FilePath(g.Output), buf.Bytes()); err != nil {
 		return errors.Format("%s: %w", msg, err)
 	}
 
@@ -238,9 +231,10 @@ func (b *BuildPlan) kustomize(
 	ctx context.Context,
 	log *slog.Logger,
 	t v1alpha4.Transformer,
-	am holos.ArtifactMap,
+	am h.ArtifactMap,
 ) error {
 	tempDir, err := os.MkdirTemp("", "holos.kustomize")
+	dir := h.FilePath(tempDir)
 	if err != nil {
 		return errors.Wrap(err)
 	}
@@ -260,18 +254,11 @@ func (b *BuildPlan) kustomize(
 
 	// Write the inputs
 	for _, input := range t.Inputs {
-		data, ok := am.Get(holos.FilePath(input))
-		if !ok {
-			return errors.Format("%s: could not get artifact %s", msg, input)
-		}
-		path := filepath.Join(tempDir, string(input))
-		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		path := h.FilePath(input)
+		if err := am.Save(dir, path); err != nil {
 			return errors.Format("%s: %w", msg, err)
 		}
-		if err := os.WriteFile(path, data, 0666); err != nil {
-			return errors.Format("%s: %w", msg, err)
-		}
-		log.DebugContext(ctx, "wrote: "+path)
+		log.DebugContext(ctx, "wrote: "+filepath.Join(string(dir), string(path)))
 	}
 
 	// Execute kustomize
@@ -282,7 +269,7 @@ func (b *BuildPlan) kustomize(
 	}
 
 	// Store the artifact
-	if err := am.Set(holos.FilePath(t.Output), result.Stdout.Bytes()); err != nil {
+	if err := am.Set(h.FilePath(t.Output), result.Stdout.Bytes()); err != nil {
 		return errors.Format("%s: %w", msg, err)
 	}
 	log.Debug("set artifact: " + string(t.Output))

--- a/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/core/v1alpha4/types_go_gen.cue
+++ b/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/core/v1alpha4/types_go_gen.cue
@@ -181,7 +181,7 @@ package v1alpha4
 // Useful for the common case of combining the output of [Helm] and [Resources]
 // [Generator] into one [Artifact] when [Kustomize] is otherwise unnecessary.
 #Join: {
-	separator?: string @go(Separator)
+	separator: string & (string | *"---\n") @go(Separator)
 }
 
 // Kustomize represents a kustomization [Transformer].

--- a/internal/generate/platforms/cue.mod/pkg/github.com/holos-run/holos/api/core/v1alpha4/types.cue
+++ b/internal/generate/platforms/cue.mod/pkg/github.com/holos-run/holos/api/core/v1alpha4/types.cue
@@ -1,0 +1,13 @@
+package v1alpha4
+
+#Transformer: {
+	kind: _
+
+	if kind == "Kustomize" {
+		kustomize: _
+	}
+
+	if kind == "Join" {
+		join: _
+	}
+}


### PR DESCRIPTION
The Join transformer was not implemented.  This patch completes the transformers we support, the Join and Kustomize transformers.

- **artifact: add Save() method to save artifacts**
- **v1alpha4: add Join transformer**
