### PR TITLE
v1alpha4: cache helm charts by version (#273)

### DIFF
--- a/api/core/v1alpha4/types.go
+++ b/api/core/v1alpha4/types.go
@@ -72,7 +72,7 @@ type Artifact struct {
 
 // Generator generates an intermediate manifest for a [Artifact].
 //
-// Each Generator in a [Artifact] must have a distinct manifest value for a
+// Each Generator in a [Artifact] must have a distinct Output value for a
 // [Transformer] to reference.
 //
 // Refer to [Resources], [Helm], and [File].
@@ -104,8 +104,7 @@ type Resources map[Kind]map[InternalLabel]Resource
 // component directory.  Multiple File generators may be used to transform
 // multiple resources.
 type File struct {
-	// Source represents a file to read relative to the component path, the
-	// [BuildPlanSpec] Component field.
+	// Source represents a file sub-path relative to the component path.
 	Source FilePath `json:"source"`
 }
 

--- a/doc/md/api/core/v1alpha4.md
+++ b/doc/md/api/core/v1alpha4.md
@@ -154,8 +154,7 @@ File represents a simple single file copy [Generator](<#Generator>). Useful with
 
 ```go
 type File struct {
-    // Source represents a file to read relative to the component path, the
-    // [BuildPlanSpec] Component field.
+    // Source represents a file sub-path relative to the component path.
     Source FilePath `json:"source"`
 }
 ```
@@ -192,7 +191,7 @@ type FilePath string
 
 Generator generates an intermediate manifest for a [Artifact](<#Artifact>).
 
-Each Generator in a [Artifact](<#Artifact>) must have a distinct manifest value for a [Transformer](<#Transformer>) to reference.
+Each Generator in a [Artifact](<#Artifact>) must have a distinct Output value for a [Transformer](<#Transformer>) to reference.
 
 Refer to [Resources](<#Resources>), [Helm](<#Helm>), and [File](<#File>).
 

--- a/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/core/v1alpha4/types_go_gen.cue
+++ b/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/core/v1alpha4/types_go_gen.cue
@@ -79,7 +79,7 @@ package v1alpha4
 
 // Generator generates an intermediate manifest for a [Artifact].
 //
-// Each Generator in a [Artifact] must have a distinct manifest value for a
+// Each Generator in a [Artifact] must have a distinct Output value for a
 // [Transformer] to reference.
 //
 // Refer to [Resources], [Helm], and [File].
@@ -115,8 +115,7 @@ package v1alpha4
 // component directory.  Multiple File generators may be used to transform
 // multiple resources.
 #File: {
-	// Source represents a file to read relative to the component path, the
-	// [BuildPlanSpec] Component field.
+	// Source represents a file sub-path relative to the component path.
 	source: #FilePath @go(Source)
 }
 


### PR DESCRIPTION
Previously helm charts were cached only by name, which is a problem
because the wrong version would be used when previously cached.

This patch caches charts by name and version to ensure changes in the
version results in pulling the new cached version.  It is the user's
responsibility to remove old versions.

This patch also ensures only a single go routine can run cacheChart() at
a time across processes.  This is necessary when rendering a platform
because multiple processes will run the Helm generator concurrently, for
example when the same chart is used for multiple environments or
customers.

The mkdir system call serves as the locking mechanism, which is robust
and atomic on all commonly used file systems.


