### PR TITLE
v1alpha4: add file generator (#277)

### DIFF
--- a/internal/builder/v1alpha4/builder.go
+++ b/internal/builder/v1alpha4/builder.go
@@ -226,7 +226,15 @@ func (b *BuildPlan) file(
 	g v1alpha4.Generator,
 	am h.ArtifactMap,
 ) error {
-	return errors.NotImplemented()
+	data, err := os.ReadFile(filepath.Join(string(b.Path), string(g.File.Source)))
+	if err != nil {
+		return errors.Wrap(err)
+	}
+	if err := am.Set(string(g.Output), data); err != nil {
+		return errors.Wrap(err)
+	}
+	log.Debug("set artifact: " + string(g.Output))
+	return nil
 }
 
 func (b *BuildPlan) helm(


### PR DESCRIPTION
Previously the file generator was unimplemented.  This patch implements
it as a simple file read into the ArtifactMap for use by the Kustomize
or Join transformers.

With this patch all v1alpha4 Core API features are implemented.
Resources, Helm, and File generators.  Kustomize and Join transformers.


