### PR TITLE
Fix typo in Helm guide

### DIFF
--- a/doc/md/guides/helm.mdx
+++ b/doc/md/guides/helm.mdx
@@ -527,7 +527,7 @@ platform/prometheus.cue
 ```cue showLineNumbers
 package holos
 
-_Platform: Components: prometheus: {
+#Platform: Components: prometheus: {
 	name:      "prometheus"
 	component: "projects/platform/components/prometheus"
 	cluster:   "local"


### PR DESCRIPTION
PROBLEM:

I was working through the Helm guide and hit a problem where Holos
didn't render the platform I expected. There weren't any components
being added to the platform BuildPlan.

SOLUTION:

Fix the CUE code to ensure we're adding components to the existing
Platform spec and not creating a whole new variable disconnected from
the Platform.

OUTCOME:

`holos render platform ./platform` renders the Prometheus component as
expected.