### PR TITLE
docs: rewrite technical overview for v1alpha5

### DIFF
--- a/doc/md/diagrams/render-component-sequence.mdx
+++ b/doc/md/diagrams/render-component-sequence.mdx
@@ -1,0 +1,31 @@
+```mermaid
+---
+title: holos render component
+---
+sequenceDiagram
+  participant HRC as holos<br />render component
+  participant CUE as CUE<br />(embedded)
+  participant G as Generator<br />(e.g. Helm)
+  participant T as Transformer<br />(e.g. Kustomize)
+  participant V as Validator<br />(e.g. CUE)
+  participant M as Manifests
+
+  HRC ->>+ CUE: Get apiVersion
+  HRC ->>+ CUE: Get BuildPlan
+  loop For each Artifact in BuildPlan concurrently
+    loop For each Generator in Artifact concurrently
+        HRC ->>+ G: Generate Config
+        G ->>+ HRC: Config
+    end
+    loop For each Transformer in Artifact sequentially
+        HRC ->>+ T: Transform Config
+        T ->>+ HRC: Config
+    end
+    loop For each Validator in Artifact concurrently
+        HRC ->>+ V: Validate Config
+        V ->>+ HRC: Valid / Invalid
+    end
+    HRC ->>+ M: Write Artifact File
+  end
+  Note over M: Ready for deployment
+```

--- a/doc/md/diagrams/render-platform-sequence.mdx
+++ b/doc/md/diagrams/render-platform-sequence.mdx
@@ -1,0 +1,22 @@
+```mermaid
+---
+title: holos render platform
+---
+sequenceDiagram
+  participant HRP as holos<br />render platform
+  participant HRC as holos<br />render component
+  participant CUE as CUE<br />(embedded)
+  participant A as Artifacts
+  participant M as Manifests
+  HRP ->>+ CUE: Get apiVersion
+  HRP ->>+ CUE: Get Platform Definition
+  loop For each Component in Platform concurrently
+    HRP ->>+ HRC: Execute
+    HRC ->>+ CUE: Get apiVersion
+    HRC ->>+ CUE: Get BuildPlan
+    HRC ->>+ A: Build Artifacts
+    A ->>+ HRC: Manifests
+    HRC ->>+ M: Write Manifest Files
+  end
+  Note over M: Ready for deployment
+```

--- a/doc/md/diagrams/rendering-overview.mdx
+++ b/doc/md/diagrams/rendering-overview.mdx
@@ -17,6 +17,7 @@ graph LR
 
     Generators[<a href="/docs/api/core/v1alpha4/#generators">Generators</a>]
     Transformers[<a href="/docs/api/core/v1alpha4/#transformer">Transformers</a>]
+    Validators[Validators<br/>TBD]
     Files[Manifest<br/>Files]
 
     Platform --> Component
@@ -27,5 +28,5 @@ graph LR
     BuildPlan --> ResourcesArtifact --> Generators
     BuildPlan --> GitOpsArtifact --> Generators
 
-    Generators --> Transformers --> Files
+    Generators --> Transformers --> Validators --> Files
 ```

--- a/doc/md/tutorial/1-overview.mdx
+++ b/doc/md/tutorial/1-overview.mdx
@@ -4,6 +4,8 @@ description: Learn how Holos integrates software into a holistic platform.
 ---
 
 import RenderingOverview from '../diagrams/rendering-overview.mdx';
+import RenderPlatformDiagram from '../diagrams/render-platform-sequence.mdx';
+import RenderComponentDiagram from '../diagrams/render-component-sequence.mdx';
 
 # Tutorial
 
@@ -25,24 +27,86 @@ At a high level, Holos provides a few major components:
 
 ## Holos' role in your organization
 
+Platform engineers run the `holos render platform` command locally and in CI to
+produce Kubernetes manifests which are committed to version control.  GitOps
+tools like ArgoCD or Flux deploy the manifests produced by Holos.
+
+Other tools focus on individual applications.  Holos focuses holistically on the
+integration of applications into a whole platform.  In this way a single one
+line configuration change, like changing the domain name, is clearly visible
+across the whole platform.
+
+Rendering a platform may produce a single ConfigMap resource or produce millions
+of lines of fully rendered manifests configuring multiple environments,
+clusters, and regions.
+
+<RenderPlatformDiagram />
+
 ## Advantages of Holos
 
 This section outlines some advantages of Holos.
 
 ### Safe
 
-### Reliable
+Holos uses [CUE] to provide strong typing and constraints to configuration data.
+Additionally, holos adds strong validation to verify the output produced by Helm
+and other tools.
+
+### Consistent
+
+Holos offers a consistent way to incorporate a wide variety of tools into a well
+defined data pipeline.  Configuration produced from CUE, Helm, and Kustomize are
+all handled with the same consistent process.
 
 ### Easy
 
+Holos makes it easy to define configuration data once, then safely use the data
+in multiple Helm charts, Kustomize bases, or any other supported component kind.
+
 ### Flexible
+
+Holos is designed to be flexible.  Holos offers flexible building blocks for
+data generation, transformation, validation, and integration.  Find the perfect
+fit for your team by assembling these building blocks to your unique needs.
+
+Holos does not have an opinion on many common aspects of platform configuration.
+For example, environments and clusters are explicitly kept out of the core and
+instead are provided as flexible, user-customizable [topics] organized as a
+recipes.
+
+<RenderComponentDiagram />
 
 ## When not to use Holos
 
 Although Holos is useful for many organizations that need to do manage
 configuration, there are also some use-cases where Holos is not a good fit.
 
-TODO
+### Implicit GitOps
+
+Holos takes an explicit view of GitOps, meaning the fully rendered manifests are
+complete.  These manifests are stored in version control without an implicit
+dependency on external systems.  If your team uses an implicit approach, meaning
+some configuration comes from elsewhere, then Holos may not be a good fit.
+
+For example, if container image tags are managed by a system outside of version
+control then holos may not be a good fit.
+
+Holos is a good fit if you're open to integrate external systems with Holos such
+that the external data becomes an input to produce the fully rendered manifests.
+
+### CUE is a Non Starter
+
+Holos heavily uses CUE.  For example, when using Holos with Helm and Kustomize,
+we no longer need to write YAML files and text templates.  All configuration is
+expressed in CUE and `holos` handles the YAML on our behalf.
+
+CUE is a relatively simple domain specific language, but it is very different
+from most other languages because of it's roots in logic programming languages.
+
+Holos is not a good fit if your team prefers to write code in YAML templates or
+turing complete general purpose languages.
+
+For more info see [Why CUE for Configuration].
 
 ## Getting Help
 
@@ -54,3 +118,5 @@ the most experienced among us.  We all start somewhere and are happy to help.
 [CUE]: https://cuelang.org/
 [Discord]: https://discord.gg/JgDVbNpye7
 [GitHub discussions]: https://github.com/holos-run/holos/discussions
+[Why CUE for Configuration]: https://holos.run/blog/why-cue-for-configuration/
+[topics]: ../topics.mdx


### PR DESCRIPTION
Attribution: following the structure and length of the tokio docs, with
some more diagrams.


