### PR TITLE
cue: fix panic with no args (#334)

### DIFF
--- a/cmd/holos/tests/cli/first-impression.txt
+++ b/cmd/holos/tests/cli/first-impression.txt
@@ -1,0 +1,2 @@
+# https://github.com/holos-run/holos/issues/334
+exec holos

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -118,7 +118,7 @@ func newOrgCmd(feature holos.Flagger) (cmd *cobra.Command) {
 }
 
 func newCueCmd() (cmd *cobra.Command) {
-	cueCmd, _ := cue.New(os.Args[2:])
+	cueCmd, _ := cue.New(os.Args[1:])
 	cmd = cueCmd.Command
 	return
 }


### PR DESCRIPTION
Fixes:

```
❯ holos
panic: runtime error: slice bounds out of range [2:1]

goroutine 1 [running]:
github.com/holos-run/holos/internal/cli.newCueCmd(...)
       /home/mike/go/pkg/mod/github.com/holos-run/holos@v0.98.1/internal/cli/root.go:121
github.com/holos-run/holos/internal/cli.New(0xc0002837c0, {0x3826e00, 0x4f60860})
       /home/mike/go/pkg/mod/github.com/holos-run/holos@v0.98.1/internal/cli/root.go:102 +0x772
main.main.MakeMain.func1()
       /home/mike/go/pkg/mod/github.com/holos-run/holos@v0.98.1/internal/cli/main.go:22 +0x5b
main.main()
       /home/mike/go/pkg/mod/github.com/holos-run/holos@v0.98.1/cmd/holos/main.go:10 +0x3e
```

Closes: #334 