### PR TITLE
helm: add support for helm template --api-versions capabilities (#330)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -153,6 +153,7 @@
     "kubelet",
     "kubelogin",
     "kubernetesobjects",
+    "kubeversion",
     "Kustomization",
     "Kustomizations",
     "kustomize",

--- a/.cspell.json
+++ b/.cspell.json
@@ -304,6 +304,7 @@
     "typemeta",
     "udev",
     "uibutton",
+    "Unmarshal",
     "unstage",
     "untar",
     "upbound",

--- a/api/author/v1alpha5/definitions.go
+++ b/api/author/v1alpha5/definitions.go
@@ -81,6 +81,8 @@ type Helm struct {
 	EnableHooks bool `cue:"true | *false"`
 	// Namespace sets the helm chart namespace flag if provided.
 	Namespace string `json:",omitempty"`
+	// APIVersions represents the helm template --api-versions flag
+	APIVersions []string `json:",omitempty"`
 
 	// BuildPlan represents the derived BuildPlan produced for the holos render
 	// component command.

--- a/api/author/v1alpha5/definitions.go
+++ b/api/author/v1alpha5/definitions.go
@@ -83,6 +83,8 @@ type Helm struct {
 	Namespace string `json:",omitempty"`
 	// APIVersions represents the helm template --api-versions flag
 	APIVersions []string `json:",omitempty"`
+	// KubeVersion represents the helm template --kube-version flag
+	KubeVersion string `json:",omitempty"`
 
 	// BuildPlan represents the derived BuildPlan produced for the holos render
 	// component command.

--- a/api/core/v1alpha5/types.go
+++ b/api/core/v1alpha5/types.go
@@ -133,6 +133,8 @@ type Helm struct {
 	EnableHooks bool `json:"enableHooks,omitempty"`
 	// Namespace represents the helm namespace flag
 	Namespace string `json:"namespace,omitempty"`
+	// APIVersions represents the helm template --api-versions flag
+	APIVersions []string `json:"apiVersions,omitempty"`
 }
 
 // Values represents [Helm] Chart values generated from CUE.

--- a/api/core/v1alpha5/types.go
+++ b/api/core/v1alpha5/types.go
@@ -135,6 +135,8 @@ type Helm struct {
 	Namespace string `json:"namespace,omitempty"`
 	// APIVersions represents the helm template --api-versions flag
 	APIVersions []string `json:"apiVersions,omitempty"`
+	// KubeVersion represents the helm template --kube-version flag
+	KubeVersion string `json:"kubeVersion,omitempty"`
 }
 
 // Values represents [Helm] Chart values generated from CUE.

--- a/cmd/holos/tests/v1alpha5/schemas/capabilities.txt
+++ b/cmd/holos/tests/v1alpha5/schemas/capabilities.txt
@@ -5,11 +5,44 @@ cmp stdout want/helm-template.yaml
 exec holos render platform ./platform
 # When no capabilities are specified
 cmp deploy/components/capabilities/capabilities.gen.yaml want/when-no-capabilities-specified.yaml
+# With APIVersions specified
 cmp deploy/components/specified/specified.gen.yaml want/with-capabilities-specified.yaml
+# With KubeVersion specified
+cmp deploy/components/kubeversion1/kubeversion1.gen.yaml want/with-kubeversion-specified.yaml
+# With both APIVersions and KubeVersion specified
+cmp deploy/components/kubeversion2/kubeversion2.gen.yaml want/with-both-specified.yaml
+-- want/with-both-specified.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kubeVersion: v1.20.0
+  name: has-foo-v1
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: http
+-- want/with-kubeversion-specified.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kubeVersion: v1.20.0
+  name: has-foo-v1beta1
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: http
 -- want/when-no-capabilities-specified.yaml --
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    kubeVersion: v1.31.0
   name: has-foo-v1beta1
 spec:
   ports:
@@ -21,6 +54,8 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    kubeVersion: v1.31.0
   name: has-foo-v1
 spec:
   ports:
@@ -42,6 +77,17 @@ Platform: Components: specified: {
         path: "components/capabilities"
         parameters: apiVersions: json.Marshal(["foo/v1","bar/v1"])
 }
+Platform: Components: kubeversion1: {
+        name: "kubeversion1"
+        path: "components/capabilities"
+        parameters: kubeVersion: "v1.20.0"
+}
+Platform: Components: kubeversion2: {
+        name: "kubeversion2"
+        path: "components/capabilities"
+        parameters: kubeVersion: "v1.20.0"
+        parameters: apiVersions: json.Marshal(["foo/v1","bar/v1"])
+}
 -- components/capabilities/capabilities.cue --
 package holos
 
@@ -55,6 +101,7 @@ Component: #Helm & {
         Chart: version: "0.1.0"
         _APIVersions: string | *"[]" @tag(apiVersions, type=string)
         APIVersions: json.Unmarshal(_APIVersions)
+        KubeVersion: string | *"v1.31.0" @tag(kubeVersion, type=string)
 }
 -- components/capabilities/vendor/0.1.0/capabilities/Chart.yaml --
 apiVersion: v2
@@ -72,6 +119,8 @@ metadata:
 {{- else }}
   name: has-foo-v1beta1
 {{- end }}
+  annotations:
+    kubeVersion: {{ .Capabilities.KubeVersion }}
 spec:
   ports:
     - port: 80
@@ -85,6 +134,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: has-foo-v1beta1
+  annotations:
+    kubeVersion: v1.31.0
 spec:
   ports:
     - port: 80

--- a/cmd/holos/tests/v1alpha5/schemas/capabilities.txt
+++ b/cmd/holos/tests/v1alpha5/schemas/capabilities.txt
@@ -1,0 +1,93 @@
+# https://github.com/holos-run/holos/issues/330
+exec holos init platform v1alpha5 --force
+exec helm template ./components/capabilities/vendor/0.1.0/capabilities
+cmp stdout want/helm-template.yaml
+exec holos render platform ./platform
+# When no capabilities are specified
+cmp deploy/components/capabilities/capabilities.gen.yaml want/when-no-capabilities-specified.yaml
+cmp deploy/components/specified/specified.gen.yaml want/with-capabilities-specified.yaml
+-- want/when-no-capabilities-specified.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: has-foo-v1beta1
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: http
+-- want/with-capabilities-specified.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: has-foo-v1
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: http
+-- platform/capabilities.cue --
+package holos
+
+import "encoding/json"
+
+Platform: Components: capabilities: {
+        name: "capabilities"
+        path: "components/capabilities"
+}
+Platform: Components: specified: {
+        name: "specified"
+        path: "components/capabilities"
+        parameters: apiVersions: json.Marshal(["foo/v1","bar/v1"])
+}
+-- components/capabilities/capabilities.cue --
+package holos
+
+import "encoding/json"
+
+holos: Component.BuildPlan
+
+Component: #Helm & {
+        Name: string @tag(holos_component_name, type=string)
+        Chart: name: "capabilities"
+        Chart: version: "0.1.0"
+        _APIVersions: string | *"[]" @tag(apiVersions, type=string)
+        APIVersions: json.Unmarshal(_APIVersions)
+}
+-- components/capabilities/vendor/0.1.0/capabilities/Chart.yaml --
+apiVersion: v2
+name: capabilities
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0
+appVersion: "1.16.0"
+-- components/capabilities/vendor/0.1.0/capabilities/templates/service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Capabilities.APIVersions.Has "foo/v1" }}
+  name: has-foo-v1
+{{- else }}
+  name: has-foo-v1beta1
+{{- end }}
+spec:
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+-- want/helm-template.yaml --
+---
+# Source: capabilities/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: has-foo-v1beta1
+spec:
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http

--- a/doc/md/api/author.md
+++ b/doc/md/api/author.md
@@ -85,6 +85,8 @@ type Helm struct {
     Namespace string `json:",omitempty"`
     // APIVersions represents the helm template --api-versions flag
     APIVersions []string `json:",omitempty"`
+    // KubeVersion represents the helm template --kube-version flag
+    KubeVersion string `json:",omitempty"`
 
     // BuildPlan represents the derived BuildPlan produced for the holos render
     // component command.

--- a/doc/md/api/author.md
+++ b/doc/md/api/author.md
@@ -83,6 +83,8 @@ type Helm struct {
     EnableHooks bool `cue:"true | *false"`
     // Namespace sets the helm chart namespace flag if provided.
     Namespace string `json:",omitempty"`
+    // APIVersions represents the helm template --api-versions flag
+    APIVersions []string `json:",omitempty"`
 
     // BuildPlan represents the derived BuildPlan produced for the holos render
     // component command.

--- a/doc/md/api/core.md
+++ b/doc/md/api/core.md
@@ -243,6 +243,8 @@ type Helm struct {
     Namespace string `json:"namespace,omitempty"`
     // APIVersions represents the helm template --api-versions flag
     APIVersions []string `json:"apiVersions,omitempty"`
+    // KubeVersion represents the helm template --kube-version flag
+    KubeVersion string `json:"kubeVersion,omitempty"`
 }
 ```
 

--- a/doc/md/api/core.md
+++ b/doc/md/api/core.md
@@ -241,6 +241,8 @@ type Helm struct {
     EnableHooks bool `json:"enableHooks,omitempty"`
     // Namespace represents the helm namespace flag
     Namespace string `json:"namespace,omitempty"`
+    // APIVersions represents the helm template --api-versions flag
+    APIVersions []string `json:"apiVersions,omitempty"`
 }
 ```
 

--- a/internal/builder/v1alpha5/builder.go
+++ b/internal/builder/v1alpha5/builder.go
@@ -333,6 +333,9 @@ func (b *BuildPlan) helm(
 	if !g.Helm.EnableHooks {
 		args = append(args, "--no-hooks")
 	}
+	for _, apiVersion := range g.Helm.APIVersions {
+		args = append(args, "--api-versions", apiVersion)
+	}
 	args = append(args,
 		"--include-crds",
 		"--values", valuesPath,

--- a/internal/builder/v1alpha5/builder.go
+++ b/internal/builder/v1alpha5/builder.go
@@ -336,6 +336,9 @@ func (b *BuildPlan) helm(
 	for _, apiVersion := range g.Helm.APIVersions {
 		args = append(args, "--api-versions", apiVersion)
 	}
+	if kubeVersion := g.Helm.KubeVersion; kubeVersion != "" {
+		args = append(args, "--kube-version", kubeVersion)
+	}
 	args = append(args,
 		"--include-crds",
 		"--values", valuesPath,

--- a/internal/cli/render/render.go
+++ b/internal/cli/render/render.go
@@ -274,17 +274,18 @@ func (t tags) Tags() []string {
 }
 
 func (t tags) String() string {
-	return strings.Join(t.Tags(), ",")
+	return strings.Join(t.Tags(), " ")
 }
 
+// Set sets a value.  Only one value per flag is supported.  For example
+// --inject=foo=bar --inject=bar=baz.  For JSON values, --inject=foo=bar,bar=baz
+// is not supported.
 func (t tags) Set(value string) error {
-	for _, item := range strings.Split(value, ",") {
-		parts := strings.SplitN(item, "=", 2)
-		if len(parts) != 2 {
-			return errors.Format("invalid format, must be tag=value")
-		}
-		t[parts[0]] = parts[1]
+	parts := strings.SplitN(value, "=", 2)
+	if len(parts) != 2 {
+		return errors.Format("invalid format, must be tag=value")
 	}
+	t[parts[0]] = parts[1]
 	return nil
 }
 

--- a/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/author/v1alpha5/definitions_go_gen.cue
+++ b/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/author/v1alpha5/definitions_go_gen.cue
@@ -92,6 +92,9 @@ import "github.com/holos-run/holos/api/core/v1alpha5:core"
 	// Namespace sets the helm chart namespace flag if provided.
 	Namespace?: string
 
+	// APIVersions represents the helm template --api-versions flag
+	APIVersions?: [...string] @go(,[]string)
+
 	// BuildPlan represents the derived BuildPlan produced for the holos render
 	// component command.
 	BuildPlan: core.#BuildPlan

--- a/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/author/v1alpha5/definitions_go_gen.cue
+++ b/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/author/v1alpha5/definitions_go_gen.cue
@@ -95,6 +95,9 @@ import "github.com/holos-run/holos/api/core/v1alpha5:core"
 	// APIVersions represents the helm template --api-versions flag
 	APIVersions?: [...string] @go(,[]string)
 
+	// KubeVersion represents the helm template --kube-version flag
+	KubeVersion?: string
+
 	// BuildPlan represents the derived BuildPlan produced for the holos render
 	// component command.
 	BuildPlan: core.#BuildPlan

--- a/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/core/v1alpha5/types_go_gen.cue
+++ b/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/core/v1alpha5/types_go_gen.cue
@@ -147,6 +147,9 @@ package core
 
 	// Namespace represents the helm namespace flag
 	namespace?: string @go(Namespace)
+
+	// APIVersions represents the helm template --api-versions flag
+	apiVersions?: [...string] @go(APIVersions,[]string)
 }
 
 // Values represents [Helm] Chart values generated from CUE.

--- a/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/core/v1alpha5/types_go_gen.cue
+++ b/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/core/v1alpha5/types_go_gen.cue
@@ -150,6 +150,9 @@ package core
 
 	// APIVersions represents the helm template --api-versions flag
 	apiVersions?: [...string] @go(APIVersions,[]string)
+
+	// KubeVersion represents the helm template --kube-version flag
+	kubeVersion?: string @go(KubeVersion)
 }
 
 // Values represents [Helm] Chart values generated from CUE.

--- a/internal/generate/platforms/cue.mod/pkg/github.com/holos-run/holos/api/author/v1alpha5/definitions.cue
+++ b/internal/generate/platforms/cue.mod/pkg/github.com/holos-run/holos/api/author/v1alpha5/definitions.cue
@@ -110,6 +110,7 @@ import (
 	EnableHooks:  _
 	Namespace?:   _
 	APIVersions?: _
+	KubeVersion?: _
 
 	Artifacts: {
 		HolosComponent: {
@@ -137,6 +138,9 @@ import (
 						}
 						if APIVersions != _|_ {
 							apiVersions: APIVersions
+						}
+						if KubeVersion != _|_ {
+							kubeVersion: KubeVersion
 						}
 					}
 				},

--- a/internal/generate/platforms/cue.mod/pkg/github.com/holos-run/holos/api/author/v1alpha5/definitions.cue
+++ b/internal/generate/platforms/cue.mod/pkg/github.com/holos-run/holos/api/author/v1alpha5/definitions.cue
@@ -106,9 +106,10 @@ import (
 		name:    string | *Name
 		release: string | *name
 	}
-	Values:      _
-	EnableHooks: _
-	Namespace?:  _
+	Values:       _
+	EnableHooks:  _
+	Namespace?:   _
+	APIVersions?: _
 
 	Artifacts: {
 		HolosComponent: {
@@ -133,6 +134,9 @@ import (
 						enableHooks: EnableHooks
 						if Namespace != _|_ {
 							namespace: Namespace
+						}
+						if APIVersions != _|_ {
+							apiVersions: APIVersions
 						}
 					}
 				},


### PR DESCRIPTION
Previously the Helm generator had no support for the --api-versions flags.  This is a problem for helm charts that conditionally render resources based on this capability.

This patch plumbs support through the author and core schemas with a new field similar to how the enable hooks field is handled.

Closes: #330 