### PR TITLE
Redirect docs to current version

### DIFF
--- a/doc/website/static/_redirects
+++ b/doc/website/static/_redirects
@@ -1,1 +1,2 @@
-/docs /docs/v1alpha5 301
+/docs /docs/v1alpha5/ 301
+/docs/ /docs/v1alpha5/ 301

--- a/doc/website/static/_redirects
+++ b/doc/website/static/_redirects
@@ -1,0 +1,1 @@
+/docs /docs/v1alpha5 301


### PR DESCRIPTION
PROBLEM:

See #350 for context. There's a GitHub issue open for this on the
facebook docusaurus repo:
https://github.com/facebook/docusaurus/issues/9049

SOLUTION:

Use the redirect workaround for the time being.

OUTCOME:

https://holos.run/docs will link to the most recent version of our docs
site.