### PR TITLE
render: pass build tags from platform to component (#366)

### DIFF
--- a/internal/builder/platform.go
+++ b/internal/builder/platform.go
@@ -15,7 +15,7 @@ import (
 // PlatformOpts represents build options when processing the components in a
 // platform.
 type PlatformOpts struct {
-	Fn          BuildFunc
+	Fn          func(context.Context, int, holos.Component) error
 	Selector    holos.Selector
 	Concurrency int
 	InfoEnabled bool
@@ -88,9 +88,6 @@ func (p *Platform) Build(ctx context.Context, opts PlatformOpts) error {
 	}
 	return nil
 }
-
-// BuildFunc is executed concurrently when processing platform components.
-type BuildFunc func(context.Context, int, holos.Component) error
 
 func LoadPlatform(i *Instance) (platform Platform, err error) {
 	err = i.Discriminate(func(tm holos.TypeMeta) error {

--- a/internal/cli/render/render.go
+++ b/internal/cli/render/render.go
@@ -72,7 +72,7 @@ func newPlatform(cfg *holos.Config, feature holos.Flagger) *cobra.Command {
 			"--log-format", cfg.LogConfig().Format(),
 		}
 		opts := builder.PlatformOpts{
-			Fn:          makePlatformRenderFunc(cmd.ErrOrStderr(), prefixArgs),
+			Fn:          makeComponentRenderFunc(cmd.ErrOrStderr(), prefixArgs, tagMap.Tags()),
 			Selector:    selector,
 			Concurrency: concurrency,
 			InfoEnabled: true,
@@ -136,7 +136,7 @@ func newComponent(cfg *holos.Config, feature holos.Flagger) *cobra.Command {
 	return cmd
 }
 
-func makePlatformRenderFunc(w io.Writer, prefixArgs []string) builder.BuildFunc {
+func makeComponentRenderFunc(w io.Writer, prefixArgs, cliTags []string) func(context.Context, int, holos.Component) error {
 	return func(ctx context.Context, idx int, component holos.Component) error {
 		select {
 		case <-ctx.Done():
@@ -149,6 +149,9 @@ func makePlatformRenderFunc(w io.Writer, prefixArgs []string) builder.BuildFunc 
 			args := make([]string, 0, 10+len(prefixArgs)+(len(tags)*2))
 			args = append(args, prefixArgs...)
 			args = append(args, "render", "component")
+			for _, tag := range cliTags {
+				args = append(args, "--inject", tag)
+			}
 			for _, tag := range tags {
 				args = append(args, "--inject", tag)
 			}

--- a/internal/cli/show.go
+++ b/internal/cli/show.go
@@ -94,6 +94,7 @@ func newShowBuildPlanCmd() (cmd *cobra.Command) {
 		buildPlanOpts := holos.NewBuildOpts(path)
 		buildPlanOpts.Stderr = cmd.ErrOrStderr()
 		buildPlanOpts.Concurrency = concurrency
+		buildPlanOpts.Tags = tagMap.Tags()
 
 		platformOpts := builder.PlatformOpts{
 			Fn:          makeBuildFunc(encoder, buildPlanOpts),
@@ -110,7 +111,7 @@ func newShowBuildPlanCmd() (cmd *cobra.Command) {
 	return cmd
 }
 
-func makeBuildFunc(encoder holos.OrderedEncoder, opts holos.BuildOpts) builder.BuildFunc {
+func makeBuildFunc(encoder holos.OrderedEncoder, opts holos.BuildOpts) func(context.Context, int, holos.Component) error {
 	return func(ctx context.Context, idx int, component holos.Component) error {
 		select {
 		case <-ctx.Done():
@@ -120,6 +121,7 @@ func makeBuildFunc(encoder holos.OrderedEncoder, opts holos.BuildOpts) builder.B
 			if err != nil {
 				return errors.Wrap(err)
 			}
+			tags = append(tags, opts.Tags...)
 			inst, err := builder.LoadInstance(component.Path(), tags)
 			if err != nil {
 				return errors.Wrap(err)

--- a/internal/holos/types.go
+++ b/internal/holos/types.go
@@ -320,6 +320,7 @@ type BuildOpts struct {
 	Stderr      io.Writer
 	WriteTo     string
 	Path        string
+	Tags        []string
 }
 
 func NewBuildOpts(path string) BuildOpts {
@@ -329,5 +330,6 @@ func NewBuildOpts(path string) BuildOpts {
 		Stderr:      os.Stderr,
 		WriteTo:     "deploy",
 		Path:        path,
+		Tags:        make([]string, 0, 10),
 	}
 }

--- a/internal/util/run.go
+++ b/internal/util/run.go
@@ -43,10 +43,11 @@ func RunCmd(ctx context.Context, name string, args ...string) (result RunResult,
 	cmd.Stdout = result.Stdout
 	cmd.Stderr = result.Stderr
 	log := logger.FromContext(ctx)
-	log.DebugContext(ctx, "running: "+name, "name", name, "args", args)
+	command := fmt.Sprintf("%s '%s'", name, strings.Join(args, "' '"))
+	log.DebugContext(ctx, "running command: "+command, "name", name, "args", args)
 	err = cmd.Run()
 	if err != nil {
-		err = fmt.Errorf("could not run command: %s %s: %w", name, strings.Join(args, " "), err)
+		err = fmt.Errorf("could not run command:\n\t%s\n\t%w", command, err)
 	}
 	return result, err
 }


### PR DESCRIPTION
Previously, build tags were not propagated from `holos render platform -t validate` through to the underlying `holos render component` command. This is a problem because validators need to be selectively enabled as a work around until we have an audit mode field.

This patch fixes the problem by propagating command line tags from the render platform command to the underlying commands.  This patch also propagates tags for the show command.

Closes: #366
