### PR TITLE
helm: add valueFiles for migration from an ApplicationSet

### DIFF
--- a/api/author/v1alpha5/definitions.go
+++ b/api/author/v1alpha5/definitions.go
@@ -84,6 +84,9 @@ type Helm struct {
 	Chart core.Chart
 	// Values represents data to marshal into a values.yaml for helm.
 	Values core.Values
+	// ValueFiles represents value files for migration from helm value
+	// hierarchies.  Use Values instead.
+	ValueFiles []core.ValueFile `json:",omitempty"`
 	// EnableHooks enables helm hooks when executing the `helm template` command.
 	EnableHooks bool `cue:"true | *false"`
 	// Namespace sets the helm chart namespace flag if provided.

--- a/api/core/v1alpha5/types.go
+++ b/api/core/v1alpha5/types.go
@@ -118,8 +118,12 @@ type Helm struct {
 	// Chart represents a helm chart to manage.
 	Chart Chart `json:"chart" yaml:"chart"`
 	// Values represents values for holos to marshal into values.yaml when
-	// rendering the chart.
+	// rendering the chart.  Values follow ValueFiles when both are provided.
 	Values Values `json:"values" yaml:"values"`
+	// ValueFiles represents hierarchial value files passed in order to the helm
+	// template -f flag.  Useful for migration from an ApplicationSet.  Use Values
+	// instead.  ValueFiles precede Values when both are provided.
+	ValueFiles []ValueFile `json:"valueFiles,omitempty" yaml:"valueFiles,omitempty"`
 	// EnableHooks enables helm hooks when executing the `helm template` command.
 	EnableHooks bool `json:"enableHooks,omitempty" yaml:"enableHooks,omitempty"`
 	// Namespace represents the helm namespace flag
@@ -128,6 +132,17 @@ type Helm struct {
 	APIVersions []string `json:"apiVersions,omitempty" yaml:"apiVersions,omitempty"`
 	// KubeVersion represents the helm template --kube-version flag
 	KubeVersion string `json:"kubeVersion,omitempty" yaml:"kubeVersion,omitempty"`
+}
+
+// ValueFile represents one Helm value file produced from CUE.
+type ValueFile struct {
+	// Name represents the file name, e.g. "region-values.yaml"
+	Name string `json:"name" yaml:"name"`
+	// Kind is a discriminator.
+	Kind string `json:"kind" yaml:"kind" cue:"\"Values\""`
+	// Values represents values for holos to marshal into the file name specified
+	// by Name when rendering the chart.
+	Values Values `json:"values,omitempty" yaml:"values,omitempty"`
 }
 
 // Values represents [Helm] Chart values generated from CUE.

--- a/doc/md/api/author.md
+++ b/doc/md/api/author.md
@@ -86,6 +86,9 @@ type Helm struct {
     Chart core.Chart
     // Values represents data to marshal into a values.yaml for helm.
     Values core.Values
+    // ValueFiles represents value files for migration from helm value
+    // hierarchies.  Use Values instead.
+    ValueFiles []core.ValueFile `json:",omitempty"`
     // EnableHooks enables helm hooks when executing the `helm template` command.
     EnableHooks bool `cue:"true | *false"`
     // Namespace sets the helm chart namespace flag if provided.

--- a/doc/md/api/core.md
+++ b/doc/md/api/core.md
@@ -43,6 +43,7 @@ Package core contains schemas for a [Platform](<#Platform>) and [BuildPlan](<#Bu
 - [type Resources](<#Resources>)
 - [type Transformer](<#Transformer>)
 - [type Validator](<#Validator>)
+- [type ValueFile](<#ValueFile>)
 - [type Values](<#Values>)
 
 
@@ -283,8 +284,12 @@ type Helm struct {
     // Chart represents a helm chart to manage.
     Chart Chart `json:"chart" yaml:"chart"`
     // Values represents values for holos to marshal into values.yaml when
-    // rendering the chart.
+    // rendering the chart.  Values follow ValueFiles when both are provided.
     Values Values `json:"values" yaml:"values"`
+    // ValueFiles represents hierarchial value files passed in order to the helm
+    // template -f flag.  Useful for migration from an ApplicationSet.  Use Values
+    // instead.  ValueFiles precede Values when both are provided.
+    ValueFiles []ValueFile `json:"valueFiles,omitempty" yaml:"valueFiles,omitempty"`
     // EnableHooks enables helm hooks when executing the `helm template` command.
     EnableHooks bool `json:"enableHooks,omitempty" yaml:"enableHooks,omitempty"`
     // Namespace represents the helm namespace flag
@@ -490,6 +495,23 @@ type Validator struct {
     Inputs []FilePath `json:"inputs" yaml:"inputs"`
     // Command represents a validation command.  Ignored unless kind is Command.
     Command Command `json:"command,omitempty" yaml:"command,omitempty"`
+}
+```
+
+<a name="ValueFile"></a>
+## type ValueFile {#ValueFile}
+
+ValueFile represents one Helm value file produced from CUE.
+
+```go
+type ValueFile struct {
+    // Name represents the file name, e.g. "region-values.yaml"
+    Name string `json:"name" yaml:"name"`
+    // Kind is a discriminator.
+    Kind string `json:"kind" yaml:"kind" cue:"\"Values\""`
+    // Values represents values for holos to marshal into the file name specified
+    // by Name when rendering the chart.
+    Values Values `json:"values,omitempty" yaml:"values,omitempty"`
 }
 ```
 

--- a/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/author/v1alpha5/definitions_go_gen.cue
+++ b/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/author/v1alpha5/definitions_go_gen.cue
@@ -95,6 +95,10 @@ import "github.com/holos-run/holos/api/core/v1alpha5:core"
 	// Values represents data to marshal into a values.yaml for helm.
 	Values: core.#Values
 
+	// ValueFiles represents value files for migration from helm value
+	// hierarchies.  Use Values instead.
+	ValueFiles?: [...core.#ValueFile] @go(,[]core.ValueFile)
+
 	// EnableHooks enables helm hooks when executing the `helm template` command.
 	EnableHooks: bool & (true | *false)
 

--- a/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/core/v1alpha5/types_go_gen.cue
+++ b/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/core/v1alpha5/types_go_gen.cue
@@ -129,8 +129,13 @@ package core
 	chart: #Chart @go(Chart)
 
 	// Values represents values for holos to marshal into values.yaml when
-	// rendering the chart.
+	// rendering the chart.  Values follow ValueFiles when both are provided.
 	values: #Values @go(Values)
+
+	// ValueFiles represents hierarchial value files passed in order to the helm
+	// template -f flag.  Useful for migration from an ApplicationSet.  Use Values
+	// instead.  ValueFiles precede Values when both are provided.
+	valueFiles?: [...#ValueFile] @go(ValueFiles,[]ValueFile)
 
 	// EnableHooks enables helm hooks when executing the `helm template` command.
 	enableHooks?: bool @go(EnableHooks)
@@ -143,6 +148,19 @@ package core
 
 	// KubeVersion represents the helm template --kube-version flag
 	kubeVersion?: string @go(KubeVersion)
+}
+
+// ValueFile represents one Helm value file produced from CUE.
+#ValueFile: {
+	// Name represents the file name, e.g. "region-values.yaml"
+	name: string @go(Name)
+
+	// Kind is a discriminator.
+	kind: string & "Values" @go(Kind)
+
+	// Values represents values for holos to marshal into the file name specified
+	// by Name when rendering the chart.
+	values?: #Values @go(Values)
 }
 
 // Values represents [Helm] Chart values generated from CUE.

--- a/internal/generate/platforms/cue.mod/pkg/github.com/holos-run/holos/api/author/v1alpha5/definitions.cue
+++ b/internal/generate/platforms/cue.mod/pkg/github.com/holos-run/holos/api/author/v1alpha5/definitions.cue
@@ -95,6 +95,7 @@ import (
 		release: string | *name
 	}
 	Values:       _
+	ValueFiles?:  _
 	EnableHooks:  _
 	Namespace?:   _
 	APIVersions?: _
@@ -110,8 +111,11 @@ import (
 					kind:   "Helm"
 					output: HelmOutput
 					helm: core.#Helm & {
-						chart:       Chart
-						values:      Values
+						chart:  Chart
+						values: Values
+						if ValueFiles != _|_ {
+							valueFiles: ValueFiles
+						}
 						enableHooks: EnableHooks
 						if Namespace != _|_ {
 							namespace: Namespace


### PR DESCRIPTION
Without this patch migrating from [helm hierarchies] to Holos requires the user to unify the value hierarchy.  This is a problem because helm hierarchies are difficult to unify because it's not clear if or why a value is used in the final results.  This makes it difficult to identify how to resolve conflicts.

This patch adds `valueFiles` field to the Helm component kind.  This field is intended to provide a direct migration path from the ApplicationSet.spec.template.spec.sources.helm.valueFiles field.  With this patch, users can directly migrate the values files to CUE using `@embed`, then directly migrate the valueFiles field to reference the values from within CUE.

Note we actively discourage the use of Helm value hierarchies.  The feature is intended as a temporary migration tool.  We encourage the use of CUE unification instead.  After migration, the valueFiles field should be refactored to the values field as one unified structure in CUE.  The valueFiles field makes this second order migration easier becuase we can inspect and verify the complete rendered output, allowing us to determine if a value is actually used in the final configuration or is overridden.

[helm hierarchies]: https://medium.com/containers-101/using-helm-hierarchies-in-multi-source-argo-cd-applications-for-promoting-to-different-gitops-133c3bc93678

Closes: #398 