### PR TITLE
docs: Update Helm version and add known issue

### DIFF
--- a/doc/md/tutorial/setup.mdx
+++ b/doc/md/tutorial/setup.mdx
@@ -84,9 +84,13 @@ Install these tools to use Holos's full capabilities:
 - [Kubectl] for [kustomize] operations
 
 :::note
-Holos is tested with Helm `v3.16.2`. If you see `Error: chart requires
+Holos is tested with Helm `v3.17.3`. If you see `Error: chart requires
 kubeVersion` errors, try upgrading Helm.
 :::
+
+## Known Issues
+
+Helm `v3.18.0` has a [known issue](https://github.com/NixOS/nixpkgs/pull/322994) that causes it to produce incorrect output. This may affect Holos users. For more details, see [Holos issue #433](https://github.com/holos-run/holos/issues/433).
 
 ## Next Steps
 


### PR DESCRIPTION
- Updates the tested Helm version to v3.17.3 in the setup documentation.
- Adds a "Known Issues" section to the setup documentation.
- Notes that Helm v3.18.0 produces incorrect output and links to the relevant Holos and Nixpkgs issues.

Fixes #433