### PR TITLE
Add ca-certificates to container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ COPY --from=build \
 # Extra packages
 # git - https://github.com/holos-run/holos/issues/440
 RUN apt update && \
-    apt install -y --no-install-recommends git && \
+    apt install -y --no-install-recommends git ca-certificates && \
     apt clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Add ca-certificates to container image to allow pulling from external sources using HTTPS.
Should address this issue:
<img width="1758" height="287" alt="image" src="https://github.com/user-attachments/assets/814bc136-6a64-4c1e-b567-fb795bad6ed9" />
as shown in a CI pipeline job.
