### PR TITLE
Allows authentication of OCI charts

### DIFF
--- a/api/core/v1alpha6/types.go
+++ b/api/core/v1alpha6/types.go
@@ -274,8 +274,8 @@ type Chart struct {
 // repository.  Holos gets the username and password from the environment
 // variables represented by the Auth field.
 type Repository struct {
-	Name string `json:"name" yaml:"name"`
-	URL  string `json:"url" yaml:"url"`
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+	URL  string `json:"url,omitempty" yaml:"url,omitempty"`
 	Auth Auth   `json:"auth,omitempty" yaml:"auth,omitempty"`
 }
 


### PR DESCRIPTION
Currently Holos does not support authentication for OCI charts, just for Helm charts.

This is because for OCI charts, the registry (host name of the chart ref) has to be authenticated before the Pull operation. This problem can be recreated using the Helm CLI directly, it's a limitation of it and not of Holos.

This changes ensure that when a OCI reference is passed and there is user and password, the authentication is done on the registry client before doing the pull.