### PR TITLE
doc: v1beta1 design review, AC cross-check, and phase exit gate

### DIFF
--- a/doc/design/v1beta1/README.md
+++ b/doc/design/v1beta1/README.md
@@ -243,3 +243,24 @@ site opinion is greppable in the profile and platform layers because the
 component layer structurally has no place to hold one.  The canonical
 worked example — a management-cluster profile — is the subject of
 [use-case.md](use-case.md).
+
+## Acceptance-criteria matrix
+
+The Phase 0 exit gate (HOL-1507): each HOL-1492 acceptance criterion mapped
+to the chapter and section that satisfies it, plus the two HOL-1491
+criteria this document set covers at the design level.
+
+| # | Criterion (abridged) | Satisfied by |
+| -- | -- | -- |
+| HOL-1492 AC 1 | Design document exists at `doc/design/v1beta1/README.md`, split into sibling files where sections exceed ~400 lines | This README ([document map](#document-map)) and the six sibling chapters it indexes |
+| HOL-1492 AC 2 | Layer model Platform → Profile → Role → Component; Profile/Role are pure CUE conventions; the Go tooling knows only Platform → Component | README, [the layer model](#the-layer-model-platform--profile--role--component) and [the normative Go-tooling rule](#normative-the-go-tooling-knows-only-platform--component) |
+| HOL-1492 AC 3 | Deep technical explanation from a Platform: compiler pool, TaskSet collection, one platform-wide DAG, topological sort, concurrent execution, result organized by Profile, Role, Component | [rendering.md](rendering.md), the compiler protocol ([R1](rendering.md#r1-wire-framing)–[R5](rendering.md#r5-proto-toolchain)) and the platform-wide DAG ([steps 1–6](rendering.md#the-platform-wide-dag)) |
+| HOL-1492 AC 4 | Canonical use case: `cilium-vxlan` Role, dependent `service-mesh` Role (Istio Ambient), `management-cluster` Profile, module trees, concrete `#Platform`/`#Profile`/`#Role`/`#Config` definitions, explicit inter-role dependency | [use-case.md](use-case.md), [the canonical target](use-case.md#the-canonical-target), [U1](use-case.md#u1-the-author-layer-and-the-flattening)–[U4](use-case.md#u4-the-inter-role-dependency-becomes-dag-edges) |
+| HOL-1492 AC 5 | Three-module composition at the Role layer (community + Security + SRE Observability) by unification, no overwrite semantics | [use-case.md U5](use-case.md#u5-three-module-composition-by-unification) |
+| HOL-1492 AC 6 | Role-layer transformation: Secret → ExternalSecret knockout without modifying the upstream module | [use-case.md U6](use-case.md#u6-the-secret--externalsecret-knockout) |
+| HOL-1492 AC 7 | First-class `Command` task modeling in the v1beta1 Task schema | [schema.md](schema.md), [Command as a first-class task kind](schema.md#command-as-a-first-class-task-kind) and [Task kinds](schema.md#task-kinds) |
+| HOL-1492 AC 8 | Rendered-resource round-trip structure keyed by file path → GVK → namespace/name, unifiable by other modules | [resources.md](resources.md), [the round-trip structure](resources.md#the-round-trip-structure) and [V1](resources.md#v1-key-formats)–[V6](resources.md#v6-unification-by-downstream-modules) |
+| HOL-1492 AC 9 | CUE module packaging: `cue mod publish` to OCI, `CUE_REGISTRY` routing, MVS, platform-layer pinning, embedded charts under `vendor/charts/`, britney2-style reverse-dependency checking | [modules.md](modules.md), [M1](modules.md#m1-publishing)–[M7](modules.md#m7-reverse-dependency-checking) |
+| HOL-1492 AC 10 | `make lint && make test` pass; docs do not break `make update-docs` | Verified on every chapter PR (#464–#469) and on the HOL-1507 review PR |
+| HOL-1491 AC 7 | Concrete canonical use case designed: Service Mesh Role (Istio Ambient) on a Cilium VXLAN data plane Role, composed by a Management Cluster Profile, with module structure and CUE type definitions | [use-case.md](use-case.md), whole chapter (design level; Phase 5 HOL-1498 implements the fixture) |
+| HOL-1491 AC 8 | `Command` modeled first-class; deep documentation of DAG compilation and execution producing a complete resource listing organized by Profile, Role, Component, suitable for unification by other modules | [schema.md](schema.md#command-as-a-first-class-task-kind), [rendering.md](rendering.md) ([step 6](rendering.md#step-6-the-result)), [use-case.md U5](use-case.md#u5-three-module-composition-by-unification) (design level; schema lands in Phase 1 HOL-1493) |

--- a/doc/design/v1beta1/resources.md
+++ b/doc/design/v1beta1/resources.md
@@ -146,8 +146,9 @@ sinks declaring the same path already fail at graph-build time
 ([rendering.md step 2](rendering.md#step-2-collect-tasksets-and-merge-into-one-dag)).
 This chapter extends that rule to prefix-freedom: no sink's final path may
 equal *or nest under* another sink's directory path — a file sink at
-`deploy/vault/rbac.yaml` conflicts with a directory sink at `deploy/vault`
-— validated at graph build with an error naming both canonical IDs.
+`components/vault/rbac.yaml` conflicts with a directory sink at
+`components/vault` — validated at graph build with an error naming both
+canonical IDs.
 Prefix-freedom guarantees every FilePath key has exactly one producing
 sink and protects the atomic directory promotion of
 [rendering.md R8](rendering.md#r8-failure-semantics), which could not

--- a/doc/design/v1beta1/schema.md
+++ b/doc/design/v1beta1/schema.md
@@ -169,8 +169,9 @@ type Command struct {
 // has completed successfully (see D2).
 type Artifact struct {
 	// Path represents the final artifact path relative to the write-to
-	// directory, e.g. deploy/.  Defaults to the task's single input path
-	// when empty.
+	// directory (deploy by default; resources.md V1 derives FilePath keys
+	// by joining it under that prefix).  Defaults to the task's single
+	// input path when empty.
 	Path FileOrDirectoryPath `json:"path,omitempty" yaml:"path,omitempty"`
 }
 ```
@@ -407,7 +408,7 @@ TaskSets: "components/vault": spec: tasks: {
 	deploy: {
 		kind:     "Artifact"
 		inputs:   ["vault.gen.yaml"]
-		artifact: path: "deploy/vault.yaml"
+		artifact: path: "components/vault/vault.gen.yaml"
 	}
 }
 ```
@@ -425,7 +426,7 @@ TaskSets: "components/argocd": spec: tasks: {
 	deploy: {
 		kind:     "Artifact"
 		inputs:   ["argocd.gen.yaml"]
-		artifact: path: "deploy/argocd.yaml"
+		artifact: path: "components/argocd/argocd.gen.yaml"
 	}
 }
 ```

--- a/doc/design/v1beta1/use-case.md
+++ b/doc/design/v1beta1/use-case.md
@@ -410,7 +410,7 @@ import core "github.com/holos-run/holos/api/core/v1beta1"
 				// The interposition seam (U5): a default the consuming role
 				// may override to rewire the data path.
 				inputs: [...string] | *["cilium.gen.yaml"]
-				artifact: path: "deploy/components/cilium/cilium.gen.yaml"
+				artifact: path: "components/cilium/cilium.gen.yaml"
 			}
 		}
 	}
@@ -505,7 +505,7 @@ import core "github.com/holos-run/holos/api/core/v1beta1"
 			deploy: {
 				kind: "Artifact"
 				inputs: [...string] | *["istiod.gen.yaml"]
-				artifact: path: "deploy/components/istiod/istiod.gen.yaml"
+				artifact: path: "components/istiod/istiod.gen.yaml"
 			}
 		}
 	}
@@ -780,7 +780,7 @@ import cilium "example.com/holos/cilium"
 			kind: "Artifact"
 			// Sinks a mixin adds follow the same seam convention (U6).
 			inputs: [...string] | *["network-policy.gen.yaml"]
-			artifact: path: "deploy/components/cilium/network-policy.gen.yaml"
+			artifact: path: "components/cilium/network-policy.gen.yaml"
 		}
 	}
 }
@@ -831,7 +831,7 @@ import cilium "example.com/holos/cilium"
 			kind: "Artifact"
 			// Sinks a mixin adds follow the same seam convention (U6).
 			inputs: [...string] | *["dashboards.gen.yaml"]
-			artifact: path: "deploy/components/cilium/dashboards.gen.yaml"
+			artifact: path: "components/cilium/dashboards.gen.yaml"
 		}
 	}
 }
@@ -962,7 +962,7 @@ default:
 deploy: {
 	kind: "Artifact"
 	inputs: [...string] | *["vault.gen.yaml"]
-	artifact: path: "deploy/components/vault/vault.gen.yaml"
+	artifact: path: "components/vault/vault.gen.yaml"
 }
 ```
 


### PR DESCRIPTION
## Summary

Phase 0 exit-gate review of the `doc/design/v1beta1/` document set (HOL-1501–HOL-1506): cross-chapter consistency sweep, symbol grounding audit, and the HOL-1492/HOL-1491 acceptance-criteria matrix.

- Fix the one real cross-chapter drift found: `Artifact` sink `path` examples in schema.md and use-case.md carried a `deploy/` prefix, contradicting the normative rule (rendering.md step 2, resources.md V1) that sink paths are relative to the write-to directory and FilePath keys join them under the `deploy` prefix. With the old examples, V1 key derivation would have produced `deploy/deploy/...`. Clarified the `Artifact.Path` doc comment and restated the resources.md V2 prefix-freedom example in sink-path terms.
- Add the acceptance-criteria matrix as the final README section, mapping HOL-1492 ACs 1–10 and HOL-1491 ACs 7–8 to the chapter and section satisfying each.

Fixes HOL-1507

## Consistency checks performed

1. **Task kind list** — identical in schema.md (CUE constraint + Task kinds table), rendering.md, and use-case.md: `Resources`, `Helm`, `File`, `Kustomize`, `Join`, `Command`, `Artifact`; the `Artifact` sink follows schema.md D2 everywhere. PASS (no fix needed).
2. **Task ID namespacing** — schema.md D3 format `<component-path>:<task-name>` is the one rendering.md step 2 uses in the DAG merge (`components/vault:helm`) and use-case.md U4 uses for role dependency edges (`components/cilium:deploy`). PASS (no fix needed).
3. **`#Resources` key formats** — resources.md V1 GVK (`v1/Secret`, `external-secrets.io/v1beta1/ExternalSecret`) and NamespacedName (`vault/vault-unseal`) formats match the use-case.md U6 knockout policy exactly; FilePath keys (`deploy/components/vault/vault.gen.yaml`) now derive correctly from the fixed sink paths. FIXED (sink-path `deploy/` prefix removed in schema.md and use-case.md; V2 example restated).
4. **Module layout tree** — identical structure in modules.md (normative tree) and use-case.md (per-module trees): `cue.mod/module.cue`, `README.md`, `config.cue`, `component.cue`, `vendor/charts/<chart>-<version>.tgz`, `examples/<name>/deploy/`. Chart versions consistent (cilium 1.16.5, istio 1.24.2, vault 0.28.0). PASS (no fix needed).
5. **Profile/Role label names** — `holos.run/profile.name` and `holos.run/role.name` are used consistently in every occurrence (all in use-case.md; other chapters reference labels without restating names). PASS (no fix needed).
6. **Decision anchors** — every decision anchor (D1–D5, R1–R8, V1–V6, M1–M7, U1–U6) and every cross-chapter section link resolves; verified with a GitHub-slugification link checker over all 7 files (README.md, schema.md, rendering.md, rendering-migration.md, resources.md, modules.md, use-case.md), including the new README matrix links. PASS.

## Symbol grounding audit

One scripted check per repo path / symbol citation; all 37 resolve. Line-range citations (e.g. `types.go` 131–174, 371–383, 108–125, 9–30; `compile.go` 31–45, 149–254, 213–228; `v1alpha6.go` 590–660, 668–711, 151–160; `platform.go` 129–157, 174–175; `artifact.go` 73–113; `cue.go` 26–27) were verified against the current sources.

<details>
<summary>Audit script output (37/37 PASS)</summary>

```
PASS: cueMutex in internal/cue/cue.go
    27:var cueMutex sync.Mutex
    32:	cueMutex.Lock()
    33:	defer cueMutex.Unlock()
PASS: concurrency comment in internal/cue/cue.go
    26:// cue context and loading is not safe for concurrent use.
PASS: TypeMetaFile in internal/holos/constants.go
    12:// TypeMetaFile represents the file holos uses to discriminate the api version
    14:const TypeMetaFile string = "typemeta.yaml"
PASS: WriteToDefault = deploy in internal/holos/constants.go
    6:const WriteToDefault string = "deploy"
PASS: BuildContextTag in api/core/v1alpha6/types.go
    9:const BuildContextTag string = "holos_build_context"
PASS: ComponentNameTag in api/core/v1alpha6/types.go
    11:// ComponentNameTag represents the cue tag holos uses to inject a [Component]
    14:const ComponentNameTag string = "holos_component_name"
PASS: ComponentPathTag in api/core/v1alpha6/types.go
    16:// ComponentPathTag represents the cue tag holos uses to inject a [Component]
    19:const ComponentPathTag string = "holos_component_path"
PASS: ComponentLabelsTag in api/core/v1alpha6/types.go
    21:// ComponentLabelsTag represents the cue tag holos uses to inject the json
    24:const ComponentLabelsTag string = "holos_component_labels"
PASS: ComponentAnnotationsTag in api/core/v1alpha6/types.go
    26:// ComponentAnnotationsTag represents the tag holos uses to inject the json
    29:const ComponentAnnotationsTag = "holos_component_annotations"
PASS: BuildPlanSpec in api/core/v1alpha6/types.go
    132:type BuildPlanSpec struct {
PASS: Artifact struct in api/core/v1alpha6/types.go
    168:type Artifact struct {
PASS: Command struct in api/core/v1alpha6/types.go
    375:type Command struct {
PASS: BuildContext struct in api/core/v1alpha6/types.go
    108:type BuildContext struct {
PASS: BuildPlanRequest in internal/compile/compile.go
    31:type BuildPlanRequest struct {
PASS: BuildPlanResponse in internal/compile/compile.go
    41:type BuildPlanResponse struct {
PASS: Compile func in internal/compile/compile.go
    155:func Compile(ctx context.Context, concurrency int, reqs []BuildPlanRequest) (resp []BuildPlanResponse, err error) {
PASS: Tags field without json tag in internal/compile/compile.go
    38:	Tags       []string
PASS: compiler() in internal/compile/compile.go
    193:func compiler(ctx context.Context, id int, tasks chan task, resp []BuildPlanResponse) error {
PASS: exec.CommandContext ctx exe compile in internal/compile/compile.go
    202:	cmd := exec.CommandContext(ctx, exe, "compile")
PASS: Build method in internal/component/v1alpha6/v1alpha6.go
    668:func (b *BuildPlan) Build(ctx context.Context) error {
PASS: buildArtifact in internal/component/v1alpha6/v1alpha6.go
    590:func buildArtifact(ctx context.Context, idx int, artifact core.Artifact, tasks chan task, buildPlanName string, opts holos.BuildOpts) error {
    702:				return buildArtifact(ctx, idx, a, tasks, b.Metadata.Name, b.Opts)
PASS: vendor version cache dir in internal/component/v1alpha6/v1alpha6.go
    154:	cacheDir := filepath.Join(t.opts.AbsLeaf(), "vendor", t.generator.Helm.Chart.Version)
PASS: onceWithLock in internal/component/v1alpha6/v1alpha6.go
    172:			return onceWithLock(log, ctx, cachePath, func() error {
    747:// onceWithLock obtains a filesystem lock with mkdir, then executes fn.  If the
    748:// lock is already locked, onceWithLock waits for it to be released then returns
    750:func onceWithLock(log *slog.Logger, ctx context.Context, path string, fn func() error) error {
PASS: helm.PullChart in internal/component/v1alpha6/v1alpha6.go
    173:				return errors.Wrap(helm.PullChart(
PASS: Platform Load in internal/platform/platform.go
    129:func (p *Platform) Load(ctx context.Context) error {
PASS: CUE memory usage comment in internal/platform/platform.go
    174:	// Limit the number of concurrent goroutines due to CUE memory usage concerns
PASS: TypeMeta method in internal/component/component.go
    43:func (c *Component) TypeMeta() (tm holos.TypeMeta, err error) {
PASS: MapStore Save in internal/artifact/artifact.go
    73:func (a *MapStore) Save(dir, path string) error {
PASS: os.WriteFile in internal/artifact/artifact.go
    90:		if err := os.WriteFile(fullPath, data, 0666); err != nil {
    106:			if err := os.WriteFile(fullPath, data, 0666); err != nil {
PASS: showBuildPlans in internal/cli/show.go
    38:	sbp := &showBuildPlans{
    73:type showBuildPlans struct {
    78:func (s *showBuildPlans) flagSet() *pflag.FlagSet {
    84:func (s *showBuildPlans) Run(ctx context.Context, p *platform.Platform) error {
PASS: BuildInstance in internal/cue/cue.go
    31:func BuildInstance(root, leaf string, tags []string) (*Instance, error) {
PASS: BuildInstance in internal/component/cue.go
    23:// BuildInstance builds the cue configuration instance at leaf relative to the
    25:func BuildInstance(root, leaf string, tags []string) (*Instance, error) {
    38:	values, err := ctxt.BuildInstances(bis)
PASS: load.Instances in internal/component/cue.go
    37:	bis := load.Instances([]string{leaf}, cfg)
PASS: embed interpreter in internal/component/cue.go
    35:	ctxt := cuecontext.New(cuecontext.Interpreter(embed.New()))
PASS: v1alpha6 design note plan items
    12:3. Deprecate BuildPlan, use a TaskSet instead.
PASS: cue-vet.txt prior art
    5:stderr 'Forbidden. Use an ExternalSecret instead.'
    12:secret: kind: "Forbidden. Use an ExternalSecret instead."
PASS: load.Instances in internal/cue/cue.go
    43:	bis := load.Instances([]string{leaf}, cfg)
```

</details>

## Test plan

- [x] `make lint` passes
- [x] `make test` passes
- [x] `make update-docs` passes (regenerated tutorial outputs showed only environment noise — dev version string and ephemeral git hashes — and were not committed)
- [x] `make website` builds successfully
- [x] Anchor/link checker over all 7 design docs reports zero broken links
