### PR TITLE
component: add v1beta1 TaskSet execution engine

### DIFF
--- a/internal/component/v1beta1/v1beta1.go
+++ b/internal/component/v1beta1/v1beta1.go
@@ -18,6 +18,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"cuelang.org/go/cue"
@@ -46,6 +47,27 @@ type TaskSet struct {
 	// directly.  Tests may instrument or replace run to observe scheduling
 	// behavior without executing task bodies.
 	runHook func(ctx context.Context, name string, run func(context.Context) error) error
+
+	// saveMu guards saved so concurrent tasks materialize each store path into
+	// the shared build temp directory at most once.
+	saveMu sync.Mutex
+	saved  map[string]error
+}
+
+// sharedSave materializes a store path into the shared build temp directory at
+// most once.  Store paths are write-once and immutable, so the first
+// materialization is authoritative; concurrent tasks consuming the same path
+// must not race by truncating and rewriting a file another task is reading.
+func (b *TaskSet) sharedSave(dir, path string) error {
+	b.saveMu.Lock()
+	defer b.saveMu.Unlock()
+	key := dir + "\x00" + path
+	if err, ok := b.saved[key]; ok {
+		return err
+	}
+	err := b.Opts.Store.Save(dir, path)
+	b.saved[key] = err
+	return err
 }
 
 // Load loads the TaskSet from a cue value.
@@ -92,6 +114,10 @@ func (b *TaskSet) Build(ctx context.Context) error {
 	if err != nil {
 		return errors.Format("%s: %w", msg, err)
 	}
+
+	b.saveMu.Lock()
+	b.saved = make(map[string]error)
+	b.saveMu.Unlock()
 
 	// Load inputs sourced from the component directory into the artifact
 	// store so tasks consume them uniformly (schema.md D1: an input matching
@@ -150,7 +176,10 @@ func (b *TaskSet) graph() (*graph, error) {
 
 	// Validate tasks and index producers.  Outputs are write-once: a second
 	// task declaring an already-declared output is an error naming both tasks.
+	// Final artifact paths are write-once for the same reason: two sinks
+	// declaring the same path is an error naming both tasks.
 	producers := make(map[string]string, len(tasks))
+	artifactPaths := make(map[string]string)
 	for _, name := range g.names {
 		task := tasks[name]
 		if err := validateTask(name, task); err != nil {
@@ -161,6 +190,16 @@ func (b *TaskSet) graph() (*graph, error) {
 				return nil, errors.Format("duplicate output %s: declared by tasks %s and %s", output, prev, name)
 			}
 			producers[output] = name
+		}
+		if task.Kind == "Artifact" {
+			path := string(task.Artifact.Path)
+			if path == "" {
+				path = string(task.Inputs[0])
+			}
+			if prev, ok := artifactPaths[path]; ok {
+				return nil, errors.Format("duplicate artifact path %s: declared by tasks %s and %s", path, prev, name)
+			}
+			artifactPaths[path] = name
 		}
 	}
 
@@ -256,11 +295,22 @@ func matchProducers(path string, producers map[string]string, outputs []string) 
 }
 
 // validateTask revalidates the per-kind constraints of schema.md at execution
-// time: task name pattern (D3) and the inputs/output requiredness and
-// cardinality table (Task kinds).
+// time: task name pattern (D3), the inputs/output requiredness and cardinality
+// table (Task kinds), and path containment.  Every declared path must stay
+// local to its root directory: store paths resolve under the build temp dir,
+// file sources under the component directory, and artifact paths under the
+// write-to directory.
 func validateTask(name string, task core.Task) error {
 	if !taskNamePattern.MatchString(name) {
 		return errors.Format("invalid task name %q: must match %s", name, taskNamePattern)
+	}
+	if output := string(task.Output); output != "" && !filepath.IsLocal(output) {
+		return errors.Format("task %s: output %s: path must be relative and must not traverse outside the build directory", name, output)
+	}
+	for _, input := range task.Inputs {
+		if !filepath.IsLocal(string(input)) {
+			return errors.Format("task %s: input %s: path must be relative and must not traverse outside the build directory", name, input)
+		}
 	}
 	switch task.Kind {
 	case "Resources", "Helm", "File":
@@ -270,12 +320,20 @@ func validateTask(name string, task core.Task) error {
 		if task.Output == "" {
 			return errors.Format("task %s: kind %s requires an output", name, task.Kind)
 		}
+		if task.Kind == "File" && !filepath.IsLocal(string(task.File.Source)) {
+			return errors.Format("task %s: file source %s: path must be relative and must not traverse outside the component directory", name, task.File.Source)
+		}
 	case "Kustomize", "Join":
 		if len(task.Inputs) < 1 {
 			return errors.Format("task %s: kind %s requires at least one input", name, task.Kind)
 		}
 		if task.Output == "" {
 			return errors.Format("task %s: kind %s requires an output", name, task.Kind)
+		}
+		for path := range task.Kustomize.Files {
+			if !filepath.IsLocal(string(path)) {
+				return errors.Format("task %s: kustomize file %s: path must be relative and must not traverse outside the kustomize directory", name, path)
+			}
 		}
 	case "Command":
 		if len(task.Command.Args) < 1 {
@@ -295,6 +353,9 @@ func validateTask(name string, task core.Task) error {
 		}
 		if task.Output != "" {
 			return errors.Format("task %s: kind Artifact must not declare an output", name)
+		}
+		if path := string(task.Artifact.Path); path != "" && !filepath.IsLocal(path) {
+			return errors.Format("task %s: artifact path %s: path must be relative and must not traverse outside the write-to directory", name, path)
 		}
 	default:
 		return errors.Format("task %s: unsupported kind %s", name, task.Kind)
@@ -426,6 +487,7 @@ func (b *TaskSet) runTask(ctx context.Context, name string) error {
 		taskSetName: b.Metadata.Name,
 		task:        b.Spec.Tasks[name],
 		opts:        b.Opts,
+		sharedSave:  b.sharedSave,
 	}
 	if b.runHook != nil {
 		return b.runHook(ctx, name, t.run)
@@ -439,6 +501,9 @@ type taskRunner struct {
 	taskSetName string
 	task        core.Task
 	opts        holos.BuildOpts
+	// sharedSave materializes a store path into the shared build temp
+	// directory at most once across concurrent tasks.
+	sharedSave func(dir, path string) error
 }
 
 // id uniquely identifies the task for log and error messages.
@@ -767,9 +832,11 @@ func (t *taskRunner) command(ctx context.Context) error {
 		return errors.Format("command args length must be at least 1")
 	}
 
-	// Write the inputs
+	// Write the inputs.  Materialization goes through sharedSave because
+	// concurrent command tasks share the build temp directory and may consume
+	// the same input path.
 	for _, input := range t.task.Inputs {
-		if err := store.Save(tempDir, string(input)); err != nil {
+		if err := t.sharedSave(tempDir, string(input)); err != nil {
 			return errors.Wrap(err)
 		}
 	}

--- a/internal/component/v1beta1/v1beta1.go
+++ b/internal/component/v1beta1/v1beta1.go
@@ -1,0 +1,971 @@
+// Package v1beta1 executes one component's [core.TaskSet].  The executor
+// derives DAG edges from task inputs/output declarations plus explicit
+// dependsOn edges per doc/design/v1beta1/schema.md D1, then executes tasks in
+// topological order with bounded concurrency.  Scope is intra-component only;
+// the platform-wide DAG belongs to Phase 2 (doc/design/v1beta1/rendering.md).
+package v1beta1
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	"cuelang.org/go/cue"
+	core "github.com/holos-run/holos/api/core/v1beta1"
+	"github.com/holos-run/holos/internal/errors"
+	"github.com/holos-run/holos/internal/helm"
+	"github.com/holos-run/holos/internal/holos"
+	"github.com/holos-run/holos/internal/logger"
+	"github.com/holos-run/holos/internal/util"
+	"golang.org/x/sync/errgroup"
+	"gopkg.in/yaml.v3"
+	"helm.sh/helm/v3/pkg/cli"
+)
+
+var _ holos.BuildPlan = &TaskSet{}
+
+// taskNamePattern validates task names per schema.md D3: an RFC 1123 label.
+var taskNamePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
+
+// TaskSet represents a component builder executing one [core.TaskSet].
+type TaskSet struct {
+	core.TaskSet
+	Opts holos.BuildOpts
+
+	// runHook is a test seam wrapping task execution.  When nil, run is called
+	// directly.  Tests may instrument or replace run to observe scheduling
+	// behavior without executing task bodies.
+	runHook func(ctx context.Context, name string, run func(context.Context) error) error
+}
+
+// Load loads the TaskSet from a cue value.
+func (b *TaskSet) Load(v cue.Value) error {
+	// First validate the value to get better error messages
+	if err := v.Validate(cue.Concrete(true)); err != nil {
+		return err
+	}
+
+	if err := v.Decode(&b.TaskSet); err != nil {
+		// If it's a CUE error, return it unwrapped to preserve CUE's error formatting
+		if v.Err() != nil {
+			return v.Err()
+		}
+		return errors.Wrap(err)
+	}
+	return nil
+}
+
+// Export encodes the TaskSet at index idx.
+func (b *TaskSet) Export(idx int, encoder holos.OrderedEncoder) error {
+	if err := encoder.Encode(idx, &b.TaskSet); err != nil {
+		return errors.Wrap(err)
+	}
+	return nil
+}
+
+// Build derives the task graph per schema.md D1, then executes tasks in
+// topological order with concurrency bounded by Opts.Concurrency.
+func (b *TaskSet) Build(ctx context.Context) error {
+	name := b.Metadata.Name
+	log := logger.FromContext(ctx).With(
+		"name", name,
+		"path", b.Opts.Leaf(),
+	)
+
+	msg := fmt.Sprintf("could not build %s", name)
+	if b.Spec.Disabled {
+		log.WarnContext(ctx, fmt.Sprintf("%s: disabled", msg))
+		return nil
+	}
+
+	g, err := b.graph()
+	if err != nil {
+		return errors.Format("%s: %w", msg, err)
+	}
+
+	// Load inputs sourced from the component directory into the artifact
+	// store so tasks consume them uniformly (schema.md D1: an input matching
+	// no output must exist in the component directory).
+	for _, path := range g.files {
+		if err := b.Opts.Store.Load(b.Opts.AbsLeaf(), path); err != nil {
+			return errors.Format("%s: could not load %s from component directory: %w", msg, path, err)
+		}
+	}
+
+	if err := b.execute(ctx, g); err != nil {
+		return errors.Format("%s: %w", msg, err)
+	}
+	return nil
+}
+
+// graph represents the task DAG derived per schema.md D1.
+type graph struct {
+	// names holds every task name sorted for deterministic iteration.
+	names []string
+	// succ maps a task to the set of tasks depending on it.
+	succ map[string]map[string]struct{}
+	// pred maps a task to the set of tasks it depends on.
+	pred map[string]map[string]struct{}
+	// files holds input paths read from the component directory, sorted.
+	files []string
+}
+
+// addEdge adds edge from -> to, ignoring duplicates (a duplicate edge is
+// harmless and legal per schema.md D1).
+func (g *graph) addEdge(from, to string) {
+	if _, ok := g.succ[from][to]; ok {
+		return
+	}
+	g.succ[from][to] = struct{}{}
+	g.pred[to][from] = struct{}{}
+}
+
+// graph validates the task set and derives DAG edges per schema.md D1:
+// inputs/output matching plus explicit dependsOn edges, unioned.  Cycles and
+// unknown references are errors naming the tasks involved.
+func (b *TaskSet) graph() (*graph, error) {
+	tasks := b.Spec.Tasks
+
+	g := &graph{
+		names: make([]string, 0, len(tasks)),
+		succ:  make(map[string]map[string]struct{}, len(tasks)),
+		pred:  make(map[string]map[string]struct{}, len(tasks)),
+	}
+	for name := range tasks {
+		g.names = append(g.names, name)
+		g.succ[name] = make(map[string]struct{})
+		g.pred[name] = make(map[string]struct{})
+	}
+	sort.Strings(g.names)
+
+	// Validate tasks and index producers.  Outputs are write-once: a second
+	// task declaring an already-declared output is an error naming both tasks.
+	producers := make(map[string]string, len(tasks))
+	for _, name := range g.names {
+		task := tasks[name]
+		if err := validateTask(name, task); err != nil {
+			return nil, err
+		}
+		if output := string(task.Output); output != "" {
+			if prev, ok := producers[output]; ok {
+				return nil, errors.Format("duplicate output %s: declared by tasks %s and %s", output, prev, name)
+			}
+			producers[output] = name
+		}
+	}
+
+	// Sorted outputs for deterministic prefix matching.
+	outputs := make([]string, 0, len(producers))
+	for output := range producers {
+		outputs = append(outputs, output)
+	}
+	sort.Strings(outputs)
+
+	files := make(map[string]struct{})
+	for _, name := range g.names {
+		task := tasks[name]
+		for _, input := range task.Inputs {
+			path := string(input)
+			matches := matchProducers(path, producers, outputs)
+			if len(matches) == 0 {
+				// The input must exist in the component directory.
+				if _, err := os.Stat(filepath.Join(b.Opts.AbsLeaf(), path)); err != nil {
+					return nil, errors.Format("task %s: input %s matches no task output and does not exist in the component directory", name, path)
+				}
+				files[path] = struct{}{}
+				continue
+			}
+			for _, producer := range matches {
+				if producer == name {
+					return nil, errors.Format("task %s: input %s matches its own output", name, path)
+				}
+				g.addEdge(producer, name)
+			}
+		}
+
+		// dependsOn adds explicit edges by task name for ordering constraints
+		// with no data flow.
+		targets := make([]string, 0, len(task.DependsOn))
+		for target := range task.DependsOn {
+			targets = append(targets, target)
+		}
+		sort.Strings(targets)
+		for _, target := range targets {
+			if _, ok := tasks[target]; !ok {
+				if strings.Contains(target, ":") {
+					return nil, errors.Format("task %s: dependsOn target %s: canonical task ids are not supported by intra-component execution", name, target)
+				}
+				return nil, errors.Format("task %s: dependsOn target %s: no such task", name, target)
+			}
+			if target == name {
+				return nil, errors.Format("task %s: dependsOn target %s: task depends on itself", name, target)
+			}
+			g.addEdge(target, name)
+		}
+	}
+
+	g.files = make([]string, 0, len(files))
+	for path := range files {
+		g.files = append(g.files, path)
+	}
+	sort.Strings(g.files)
+
+	if err := checkCycles(g); err != nil {
+		return nil, err
+	}
+
+	return g, nil
+}
+
+// matchProducers finds the tasks producing input path per schema.md D1.
+// Three rules are tried in order; the first rule yielding matches wins.
+func matchProducers(path string, producers map[string]string, outputs []string) []string {
+	// Rule 1: exact match.
+	if producer, ok := producers[path]; ok {
+		return []string{producer}
+	}
+	// Rule 2: directory input.  A directory input may legitimately match
+	// several producers and gains an edge from each.
+	var matches []string
+	prefix := path + "/"
+	for _, output := range outputs {
+		if strings.HasPrefix(output, prefix) {
+			matches = append(matches, producers[output])
+		}
+	}
+	if len(matches) > 0 {
+		return matches
+	}
+	// Rule 3: directory output.  The input falls under a produced directory.
+	for _, output := range outputs {
+		if strings.HasPrefix(path, output+"/") {
+			matches = append(matches, producers[output])
+		}
+	}
+	return matches
+}
+
+// validateTask revalidates the per-kind constraints of schema.md at execution
+// time: task name pattern (D3) and the inputs/output requiredness and
+// cardinality table (Task kinds).
+func validateTask(name string, task core.Task) error {
+	if !taskNamePattern.MatchString(name) {
+		return errors.Format("invalid task name %q: must match %s", name, taskNamePattern)
+	}
+	switch task.Kind {
+	case "Resources", "Helm", "File":
+		if len(task.Inputs) != 0 {
+			return errors.Format("task %s: kind %s must not declare inputs", name, task.Kind)
+		}
+		if task.Output == "" {
+			return errors.Format("task %s: kind %s requires an output", name, task.Kind)
+		}
+	case "Kustomize", "Join":
+		if len(task.Inputs) < 1 {
+			return errors.Format("task %s: kind %s requires at least one input", name, task.Kind)
+		}
+		if task.Output == "" {
+			return errors.Format("task %s: kind %s requires an output", name, task.Kind)
+		}
+	case "Command":
+		if len(task.Command.Args) < 1 {
+			return errors.Format("task %s: command args length must be at least 1", name)
+		}
+		if task.Command.IsStdoutOutput && task.Output == "" {
+			return errors.Format("task %s: kind Command requires an output when isStdoutOutput is true", name)
+		}
+		if stdin := task.Command.Stdin; stdin != "" {
+			if !slices.Contains(task.Inputs, stdin) {
+				return errors.Format("task %s: command stdin %s must be one of the task inputs", name, stdin)
+			}
+		}
+	case "Artifact":
+		if len(task.Inputs) != 1 {
+			return errors.Format("task %s: kind Artifact requires exactly one input", name)
+		}
+		if task.Output != "" {
+			return errors.Format("task %s: kind Artifact must not declare an output", name)
+		}
+	default:
+		return errors.Format("task %s: unsupported kind %s", name, task.Kind)
+	}
+	return nil
+}
+
+// checkCycles runs Kahn's algorithm over the graph.  Any cycle is an error
+// reported with the full cycle path per schema.md D1.
+func checkCycles(g *graph) error {
+	indegree := make(map[string]int, len(g.names))
+	queue := make([]string, 0, len(g.names))
+	for _, name := range g.names {
+		indegree[name] = len(g.pred[name])
+		if indegree[name] == 0 {
+			queue = append(queue, name)
+		}
+	}
+	processed := 0
+	for len(queue) > 0 {
+		name := queue[0]
+		queue = queue[1:]
+		processed++
+		for succ := range g.succ[name] {
+			indegree[succ]--
+			if indegree[succ] == 0 {
+				queue = append(queue, succ)
+			}
+		}
+	}
+	if processed == len(g.names) {
+		return nil
+	}
+
+	// Every remaining task participates in or depends on a cycle.  Walk
+	// predecessors from the smallest remaining task until one repeats.
+	remaining := make(map[string]bool, len(g.names)-processed)
+	var start string
+	for _, name := range g.names {
+		if indegree[name] > 0 {
+			remaining[name] = true
+			if start == "" {
+				start = name
+			}
+		}
+	}
+	seen := make(map[string]int)
+	path := make([]string, 0, len(remaining))
+	cur := start
+	for {
+		if idx, ok := seen[cur]; ok {
+			cycle := path[idx:]
+			// Predecessor walk yields the cycle in reverse execution order.
+			slices.Reverse(cycle)
+			return errors.Format("cycle detected: %s -> %s", strings.Join(cycle, " -> "), cycle[0])
+		}
+		seen[cur] = len(path)
+		path = append(path, cur)
+		// Deterministically choose the smallest remaining predecessor.
+		next := ""
+		for pred := range g.pred[cur] {
+			if remaining[pred] && (next == "" || pred < next) {
+				next = pred
+			}
+		}
+		cur = next
+	}
+}
+
+// execute runs tasks in topological order.  Ready tasks run concurrently on
+// an errgroup bounded by Opts.Concurrency.  The ready queue is kept sorted by
+// task name so dispatch order is a deterministic function of completion order.
+func (b *TaskSet) execute(ctx context.Context, g *graph) error {
+	eg, egctx := errgroup.WithContext(ctx)
+	eg.SetLimit(max(1, b.Opts.Concurrency))
+
+	indegree := make(map[string]int, len(g.names))
+	ready := make([]string, 0, len(g.names))
+	for _, name := range g.names {
+		indegree[name] = len(g.pred[name])
+		if indegree[name] == 0 {
+			ready = append(ready, name)
+		}
+	}
+
+	// completions is buffered for every task so workers never block sending.
+	completions := make(chan string, len(g.names))
+	pending := len(g.names)
+
+	for pending > 0 {
+		// Dispatch every ready task in sorted order.  Go blocks when the
+		// concurrency limit is reached until a worker returns.
+		for len(ready) > 0 && egctx.Err() == nil {
+			name := ready[0]
+			ready = ready[1:]
+			eg.Go(func() error {
+				if err := egctx.Err(); err != nil {
+					return err
+				}
+				if err := b.runTask(egctx, name); err != nil {
+					return err
+				}
+				completions <- name
+				return nil
+			})
+		}
+
+		select {
+		case name := <-completions:
+			pending--
+			for succ := range g.succ[name] {
+				indegree[succ]--
+				if indegree[succ] == 0 {
+					idx, _ := slices.BinarySearch(ready, succ)
+					ready = slices.Insert(ready, idx, succ)
+				}
+			}
+		case <-egctx.Done():
+			return eg.Wait()
+		}
+	}
+	return eg.Wait()
+}
+
+// runTask executes one task by kind.
+func (b *TaskSet) runTask(ctx context.Context, name string) error {
+	t := &taskRunner{
+		name:        name,
+		taskSetName: b.Metadata.Name,
+		task:        b.Spec.Tasks[name],
+		opts:        b.Opts,
+	}
+	if b.runHook != nil {
+		return b.runHook(ctx, name, t.run)
+	}
+	return t.run(ctx)
+}
+
+// taskRunner executes one [core.Task].
+type taskRunner struct {
+	name        string
+	taskSetName string
+	task        core.Task
+	opts        holos.BuildOpts
+}
+
+// id uniquely identifies the task for log and error messages.
+func (t *taskRunner) id() string {
+	return fmt.Sprintf("%s:%s/%s", t.opts.Leaf(), t.taskSetName, t.name)
+}
+
+func (t *taskRunner) tempDir() (string, error) {
+	if tempDir := t.opts.TempDir(); tempDir == "" {
+		return "", errors.Format("missing build context temp directory")
+	} else {
+		return tempDir, nil
+	}
+}
+
+func (t *taskRunner) run(ctx context.Context) error {
+	log := logger.FromContext(ctx)
+	log.DebugContext(ctx, fmt.Sprintf("task %s starting", t.id()))
+	msg := fmt.Sprintf("could not build %s", t.id())
+	switch t.task.Kind {
+	case "Resources":
+		if err := t.resources(); err != nil {
+			return errors.Format("%s: could not generate resources: %w", msg, err)
+		}
+	case "Helm":
+		if err := t.helm(ctx); err != nil {
+			return errors.Format("%s: could not generate helm: %w", msg, err)
+		}
+	case "File":
+		if err := t.file(); err != nil {
+			return errors.Format("%s: could not generate file: %w", msg, err)
+		}
+	case "Kustomize":
+		if err := t.kustomize(ctx); err != nil {
+			return errors.Format("%s: could not kustomize: %w", msg, err)
+		}
+	case "Join":
+		if err := t.join(); err != nil {
+			return errors.Format("%s: could not join: %w", msg, err)
+		}
+	case "Command":
+		if err := t.command(ctx); err != nil {
+			return errors.Format("%s: could not run command: %w", msg, err)
+		}
+	case "Artifact":
+		if err := t.artifact(ctx); err != nil {
+			return errors.Format("%s: could not write artifact: %w", msg, err)
+		}
+	default:
+		return errors.Format("%s: unsupported kind %s", msg, t.task.Kind)
+	}
+	log.DebugContext(ctx, fmt.Sprintf("task %s finished ok", t.id()))
+	return nil
+}
+
+// resources marshals kubernetes resources defined in CUE into the output.
+func (t *taskRunner) resources() error {
+	var size int
+	for _, m := range t.task.Resources {
+		size += len(m)
+	}
+	list := make([]core.Resource, 0, size)
+
+	for _, m := range t.task.Resources {
+		for _, r := range m {
+			list = append(list, r)
+		}
+	}
+
+	msg := fmt.Sprintf("could not generate %s for %s", t.task.Output, t.id())
+
+	buf, err := marshal(list)
+	if err != nil {
+		return errors.Format("%s: %w", msg, err)
+	}
+
+	if err := t.opts.Store.Set(string(t.task.Output), buf.Bytes()); err != nil {
+		return errors.Format("%s: %w", msg, err)
+	}
+
+	return nil
+}
+
+// file reads a file from the component directory into the output.
+func (t *taskRunner) file() error {
+	data, err := os.ReadFile(filepath.Join(t.opts.AbsLeaf(), string(t.task.File.Source)))
+	if err != nil {
+		return errors.Wrap(err)
+	}
+	if err := t.opts.Store.Set(string(t.task.Output), data); err != nil {
+		return errors.Wrap(err)
+	}
+	return nil
+}
+
+// helm renders a helm chart into the output.  The chart is cached per version
+// per component and pulled at most once guarded by a filesystem lock.
+func (t *taskRunner) helm(ctx context.Context) error {
+	h := t.task.Helm
+	// Cache the chart by version to pull new versions. (#273)
+	cacheDir := filepath.Join(t.opts.AbsLeaf(), "vendor", h.Chart.Version)
+	cachePath := filepath.Join(cacheDir, filepath.Base(h.Chart.Name))
+
+	log := logger.FromContext(ctx)
+
+	username := h.Chart.Repository.Auth.Username.Value
+	if username == "" {
+		username = os.Getenv(h.Chart.Repository.Auth.Username.FromEnv)
+	}
+	password := h.Chart.Repository.Auth.Password.Value
+	if password == "" {
+		password = os.Getenv(h.Chart.Repository.Auth.Password.FromEnv)
+	}
+
+	if _, err := os.Stat(cachePath); os.IsNotExist(err) {
+		err := func() error {
+			ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+			defer cancel()
+			return onceWithLock(log, ctx, cachePath, func() error {
+				return errors.Wrap(helm.PullChart(
+					ctx,
+					cli.New(),
+					h.Chart.Name,
+					h.Chart.Version,
+					h.Chart.Repository.URL,
+					cacheDir,
+					username,
+					password,
+				))
+			})
+		}()
+		if err != nil {
+			return errors.Format("could not cache chart: %w", err)
+		}
+	}
+
+	// Write value files
+	tempDir, err := os.MkdirTemp("", "holos.helm")
+	if err != nil {
+		return errors.Format("could not make temp dir: %w", err)
+	}
+	defer util.Remove(ctx, tempDir)
+
+	// valueFiles represents the ordered list of value files to pass to helm
+	// template -f
+	var valueFiles []string
+
+	// valueFiles for the use case of migration from helm value hierarchies.
+	for _, valueFile := range h.ValueFiles {
+		var data []byte
+		switch valueFile.Kind {
+		case "Values":
+			if data, err = yaml.Marshal(valueFile.Values); err != nil {
+				return errors.Format("could not marshal value file %s: %w", valueFile.Name, err)
+			}
+		default:
+			return errors.Format("could not marshal value file %s: unknown kind %s", valueFile.Name, valueFile.Kind)
+		}
+
+		valuesPath := filepath.Join(tempDir, valueFile.Name)
+		if err := os.WriteFile(valuesPath, data, 0666); err != nil {
+			return errors.Wrap(fmt.Errorf("could not write value file %s: %w", valueFile.Name, err))
+		}
+		log.DebugContext(ctx, fmt.Sprintf("wrote: %s", valuesPath))
+		valueFiles = append(valueFiles, valuesPath)
+	}
+
+	// The final values files
+	data, err := yaml.Marshal(h.Values)
+	if err != nil {
+		return errors.Format("could not marshal values: %w", err)
+	}
+
+	valuesPath := filepath.Join(tempDir, "values.yaml")
+	if err := os.WriteFile(valuesPath, data, 0666); err != nil {
+		return errors.Wrap(fmt.Errorf("could not write values: %w", err))
+	}
+	log.DebugContext(ctx, fmt.Sprintf("wrote: %s", valuesPath))
+	valueFiles = append(valueFiles, valuesPath)
+
+	// Run charts
+	args := []string{"template"}
+	if !h.EnableHooks {
+		args = append(args, "--no-hooks")
+	}
+	for _, apiVersion := range h.APIVersions {
+		args = append(args, "--api-versions", apiVersion)
+	}
+	if kubeVersion := h.KubeVersion; kubeVersion != "" {
+		args = append(args, "--kube-version", kubeVersion)
+	}
+	args = append(args, "--include-crds")
+	for _, valueFilePath := range valueFiles {
+		args = append(args, "--values", valueFilePath)
+	}
+	args = append(args,
+		"--namespace", h.Namespace,
+		"--kubeconfig", "/dev/null",
+		"--version", h.Chart.Version,
+		h.Chart.Release,
+		cachePath,
+	)
+	helmOut, err := util.RunCmd(ctx, "helm", args...)
+	if err != nil {
+		stderr := helmOut.Stderr.String()
+		lines := strings.Split(stderr, "\n")
+		for _, line := range lines {
+			log.DebugContext(ctx, line)
+			if strings.HasPrefix(line, "Error:") {
+				err = fmt.Errorf("%s: %w", line, err)
+			}
+		}
+		return errors.Format("could not run helm template: %w", err)
+	}
+
+	// Set the artifact
+	if err := t.opts.Store.Set(string(t.task.Output), helmOut.Stdout.Bytes()); err != nil {
+		return errors.Format("could not store helm output: %w", err)
+	}
+	log.Debug("set artifact: " + string(t.task.Output))
+
+	return nil
+}
+
+// kustomize executes the kustomize command in an isolated temporary directory
+// and captures standard output.
+func (t *taskRunner) kustomize(ctx context.Context) error {
+	store := t.opts.Store
+	msg := fmt.Sprintf("could not transform %s for %s", t.task.Output, t.id())
+
+	// Unlike other tasks, kustomize operates in a dedicated temporary directory.
+	tempDir, err := os.MkdirTemp("", "holos.kustomize")
+	if err != nil {
+		return errors.Wrap(err)
+	}
+	defer util.Remove(ctx, tempDir)
+
+	// Write the kustomization
+	data, err := yaml.Marshal(t.task.Kustomize.Kustomization)
+	if err != nil {
+		return errors.Format("%s: %w", msg, err)
+	}
+	path := filepath.Join(tempDir, "kustomization.yaml")
+	if err := os.WriteFile(path, data, 0666); err != nil {
+		return errors.Format("%s: %w", msg, err)
+	}
+
+	// Write additional files, e.g. patch files.
+	for name, content := range t.task.Kustomize.Files {
+		path := filepath.Join(tempDir, string(name))
+		if err := os.MkdirAll(filepath.Dir(path), 0777); err != nil {
+			return errors.Format("%s: %w", msg, err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0666); err != nil {
+			return errors.Format("%s: %w", msg, err)
+		}
+	}
+
+	// Write the inputs
+	for _, input := range t.task.Inputs {
+		if err := store.Save(tempDir, string(input)); err != nil {
+			return errors.Format("%s: %w", msg, err)
+		}
+	}
+
+	// Execute kustomize
+	r, err := util.RunCmdW(ctx, t.opts.Stderr, "kubectl", "kustomize", tempDir)
+	if err != nil {
+		return errors.Format("%s: could not run kustomize: %w", msg, err)
+	}
+
+	// Store the artifact
+	if err := store.Set(string(t.task.Output), r.Stdout.Bytes()); err != nil {
+		return errors.Format("%s: %w", msg, err)
+	}
+
+	return nil
+}
+
+// join concatenates the inputs into the output with a separator.
+func (t *taskRunner) join() error {
+	store := t.opts.Store
+	s := make([][]byte, 0, len(t.task.Inputs))
+	for _, input := range t.task.Inputs {
+		if data, ok := store.Get(string(input)); ok {
+			s = append(s, data)
+		} else {
+			return errors.Format("missing input %s", input)
+		}
+	}
+	tempDir, err := t.tempDir()
+	if err != nil {
+		return errors.Wrap(err)
+	}
+	// Join the inputs
+	data := bytes.Join(s, []byte(t.task.Join.Separator))
+	// Save the output to the filesystem.
+	outPath := filepath.Join(tempDir, string(t.task.Output))
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o777); err != nil {
+		return errors.Wrap(err)
+	}
+	if err := os.WriteFile(outPath, data, 0o666); err != nil {
+		return errors.Wrap(err)
+	}
+	// Store the output in the artifact map.
+	if err := store.Load(tempDir, string(t.task.Output)); err != nil {
+		return errors.Wrap(err)
+	}
+	return nil
+}
+
+// command executes a user defined command with the working directory set to
+// the platform root.  Declared inputs are materialized in the build temp dir
+// before the command runs.  A command with an output generates or transforms;
+// a command with only inputs validates.
+func (t *taskRunner) command(ctx context.Context) error {
+	store := t.opts.Store
+
+	tempDir, err := t.tempDir()
+	if err != nil {
+		return errors.Wrap(err)
+	}
+
+	args := t.task.Command.Args
+	if len(args) < 1 {
+		return errors.Format("command args length must be at least 1")
+	}
+
+	// Write the inputs
+	for _, input := range t.task.Inputs {
+		if err := store.Save(tempDir, string(input)); err != nil {
+			return errors.Wrap(err)
+		}
+	}
+
+	// Set the command working directory to the platform root and wire stdin
+	// to the named input.
+	preRun := func(c *exec.Cmd) error {
+		c.Dir = t.opts.Root()
+		if stdin := string(t.task.Command.Stdin); stdin != "" {
+			data, ok := store.Get(stdin)
+			if !ok {
+				return errors.Format("stdin input %s not found in the artifact store", stdin)
+			}
+			c.Stdin = bytes.NewReader(data)
+		}
+		return nil
+	}
+	r, err := util.RunCmdFunc(ctx, t.opts.Stderr, args[0], args[1:], preRun)
+	if err != nil {
+		return errors.Wrap(err)
+	}
+
+	// A command with no output validates; there is nothing to store.
+	output := string(t.task.Output)
+	if output == "" {
+		return nil
+	}
+
+	// Save the output.
+	outPath := filepath.Join(tempDir, output)
+	if t.task.Command.IsStdoutOutput {
+		if err := os.MkdirAll(filepath.Dir(outPath), 0o777); err != nil {
+			return errors.Wrap(err)
+		}
+		if err := os.WriteFile(outPath, r.Stdout.Bytes(), 0o666); err != nil {
+			return errors.Wrap(err)
+		}
+	}
+	if err := store.Load(tempDir, output); err != nil {
+		return errors.Wrap(err)
+	}
+
+	return nil
+}
+
+// artifact writes the single input from the artifact store to the final
+// artifact path relative to the write-to directory (schema.md D2).
+func (t *taskRunner) artifact(ctx context.Context) error {
+	store := t.opts.Store
+	input := string(t.task.Inputs[0])
+	path := string(t.task.Artifact.Path)
+	if path == "" {
+		path = input
+	}
+
+	log := logger.FromContext(ctx)
+
+	if path == input {
+		if err := store.Save(t.opts.AbsWriteTo(), path); err != nil {
+			return errors.Wrap(err)
+		}
+		log.DebugContext(ctx, fmt.Sprintf("wrote %s", filepath.Join(t.opts.AbsWriteTo(), path)))
+		return nil
+	}
+
+	fullPath := filepath.Join(t.opts.AbsWriteTo(), path)
+
+	// A single file input renames to the artifact path.
+	if data, ok := store.Get(input); ok {
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0777); err != nil {
+			return errors.Wrap(err)
+		}
+		if err := os.WriteFile(fullPath, data, 0666); err != nil {
+			return errors.Wrap(err)
+		}
+		log.DebugContext(ctx, fmt.Sprintf("wrote %s", fullPath))
+		return nil
+	}
+
+	// A directory input stages to a temp dir then copies to the artifact path.
+	stageDir, err := os.MkdirTemp("", "holos.artifact")
+	if err != nil {
+		return errors.Wrap(err)
+	}
+	defer util.Remove(ctx, stageDir)
+	if err := store.Save(stageDir, input); err != nil {
+		return errors.Wrap(err)
+	}
+	srcDir := filepath.Join(stageDir, input)
+	if _, err := os.Stat(srcDir); err != nil {
+		return errors.Format("missing input %s: %w", input, err)
+	}
+	if err := os.MkdirAll(fullPath, 0777); err != nil {
+		return errors.Wrap(err)
+	}
+	if err := os.CopyFS(fullPath, os.DirFS(srcDir)); err != nil {
+		return errors.Wrap(err)
+	}
+	log.DebugContext(ctx, fmt.Sprintf("wrote %s", fullPath))
+	return nil
+}
+
+func marshal(list []core.Resource) (buf bytes.Buffer, err error) {
+	encoder := yaml.NewEncoder(&buf)
+	defer encoder.Close()
+	for _, item := range list {
+		if err = encoder.Encode(item); err != nil {
+			return
+		}
+	}
+	return
+}
+
+// onceWithLock obtains a filesystem lock with mkdir, then executes fn.  If the
+// lock is already locked, onceWithLock waits for it to be released then returns
+// without calling fn.
+func onceWithLock(log *slog.Logger, ctx context.Context, path string, fn func() error) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0777); err != nil {
+		return errors.Wrap(err)
+	}
+
+	// Obtain a lock with a timeout.
+	lockDir := path + ".lock"
+	log = log.With("lock", lockDir)
+
+	err := os.Mkdir(lockDir, 0777)
+	if err == nil {
+		defer os.RemoveAll(lockDir)
+		log.DebugContext(ctx, fmt.Sprintf("acquired %s", lockDir))
+		if err := fn(); err != nil {
+			return errors.Wrap(err)
+		}
+		log.DebugContext(ctx, fmt.Sprintf("released %s", lockDir))
+		return nil
+	}
+
+	// Wait until the lock is released then return.
+	if os.IsExist(err) {
+		log.DebugContext(ctx, fmt.Sprintf("blocked %s", lockDir))
+		stillBlocked := time.After(5 * time.Second)
+		deadLocked := time.After(10 * time.Second)
+		for {
+			select {
+			case <-stillBlocked:
+				log.WarnContext(ctx, fmt.Sprintf("waiting for %s to be released", lockDir))
+			case <-deadLocked:
+				log.WarnContext(ctx, fmt.Sprintf("still waiting for %s to be released (dead lock?)", lockDir))
+			case <-time.After(100 * time.Millisecond):
+				if _, err := os.Stat(lockDir); os.IsNotExist(err) {
+					log.DebugContext(ctx, fmt.Sprintf("unblocked %s", lockDir))
+					return nil
+				}
+			case <-ctx.Done():
+				return errors.Wrap(ctx.Err())
+			}
+		}
+	}
+
+	// Unexpected error
+	return errors.Wrap(err)
+}
+
+// BuildContext represents a core BuildContext with version specific helper
+// methods.
+type BuildContext struct {
+	core.BuildContext
+}
+
+// Tags returns the cue tags injecting the build context into the TaskSet.
+func (bc BuildContext) Tags() ([]string, error) {
+	tags := make([]string, 0, 1)
+	data, err := json.Marshal(bc.BuildContext)
+	if err != nil {
+		return tags, errors.Format("could not marshall build context to json: %w", err)
+	}
+	tags = append(tags, fmt.Sprintf("%s=%s", core.BuildContextTag, string(data)))
+	return tags, nil
+}
+
+// NewBuildContext returns a new BuildContext
+func NewBuildContext(opts holos.BuildOpts) (*BuildContext, error) {
+	root := opts.Root()
+	if !filepath.IsAbs(root) {
+		return nil, errors.Format("not an absolute path: %s", root)
+	}
+	holosExecutable, err := util.Executable()
+	if err != nil {
+		return nil, errors.Format("could not get holos executable path: %w", err)
+	}
+	bc := &BuildContext{
+		BuildContext: core.BuildContext{
+			TempDir:         opts.TempDir(),
+			RootDir:         root,
+			LeafDir:         opts.Leaf(),
+			HolosExecutable: holosExecutable,
+		},
+	}
+	return bc, nil
+}

--- a/internal/component/v1beta1/v1beta1.go
+++ b/internal/component/v1beta1/v1beta1.go
@@ -121,11 +121,22 @@ func (b *TaskSet) Build(ctx context.Context) error {
 
 	// Load inputs sourced from the component directory into the artifact
 	// store so tasks consume them uniformly (schema.md D1: an input matching
-	// no output must exist in the component directory).
+	// no output must exist in the component directory).  Skip paths covered
+	// by an already loaded directory: the store is write-once, so loading
+	// base and base/patch.yaml independently would fail on the second load.
+	// g.files is sorted, so a directory sorts before the paths under it.
+	loaded := make([]string, 0, len(g.files))
+outer:
 	for _, path := range g.files {
+		for _, dir := range loaded {
+			if strings.HasPrefix(path, dir+"/") {
+				continue outer
+			}
+		}
 		if err := b.Opts.Store.Load(b.Opts.AbsLeaf(), path); err != nil {
 			return errors.Format("%s: could not load %s from component directory: %w", msg, path, err)
 		}
+		loaded = append(loaded, path)
 	}
 
 	if err := b.execute(ctx, g); err != nil {
@@ -200,6 +211,21 @@ func (b *TaskSet) graph() (*graph, error) {
 				return nil, errors.Format("duplicate artifact path %s: declared by tasks %s and %s", path, prev, name)
 			}
 			artifactPaths[path] = name
+		}
+	}
+
+	// Final artifact paths must be prefix-free: a directory sink and a file
+	// sink under it write the same final file nondeterministically.
+	sinkPaths := make([]string, 0, len(artifactPaths))
+	for path := range artifactPaths {
+		sinkPaths = append(sinkPaths, path)
+	}
+	sort.Strings(sinkPaths)
+	for _, path := range sinkPaths {
+		for _, other := range sinkPaths {
+			if strings.HasPrefix(other, path+"/") {
+				return nil, errors.Format("artifact path %s declared by task %s overlaps artifact path %s declared by task %s", other, artifactPaths[other], path, artifactPaths[path])
+			}
 		}
 	}
 
@@ -893,16 +919,21 @@ func (t *taskRunner) artifact(ctx context.Context) error {
 	}
 
 	log := logger.FromContext(ctx)
+	fullPath := filepath.Join(t.opts.AbsWriteTo(), path)
+
+	// Replace the destination so a re-render never leaves stale files from a
+	// previous render under a directory artifact.
+	if err := os.RemoveAll(fullPath); err != nil {
+		return errors.Wrap(err)
+	}
 
 	if path == input {
 		if err := store.Save(t.opts.AbsWriteTo(), path); err != nil {
 			return errors.Wrap(err)
 		}
-		log.DebugContext(ctx, fmt.Sprintf("wrote %s", filepath.Join(t.opts.AbsWriteTo(), path)))
+		log.DebugContext(ctx, fmt.Sprintf("wrote %s", fullPath))
 		return nil
 	}
-
-	fullPath := filepath.Join(t.opts.AbsWriteTo(), path)
 
 	// A single file input renames to the artifact path.
 	if data, ok := store.Get(input); ok {

--- a/internal/component/v1beta1/v1beta1.go
+++ b/internal/component/v1beta1/v1beta1.go
@@ -221,12 +221,8 @@ func (b *TaskSet) graph() (*graph, error) {
 		sinkPaths = append(sinkPaths, path)
 	}
 	sort.Strings(sinkPaths)
-	for _, path := range sinkPaths {
-		for _, other := range sinkPaths {
-			if strings.HasPrefix(other, path+"/") {
-				return nil, errors.Format("artifact path %s declared by task %s overlaps artifact path %s declared by task %s", other, artifactPaths[other], path, artifactPaths[path])
-			}
-		}
+	if err := checkPrefixFree("artifact path", artifactPaths, sinkPaths); err != nil {
+		return nil, err
 	}
 
 	// Sorted outputs for deterministic prefix matching.
@@ -235,6 +231,9 @@ func (b *TaskSet) graph() (*graph, error) {
 		outputs = append(outputs, output)
 	}
 	sort.Strings(outputs)
+	if err := checkPrefixFree("output", producers, outputs); err != nil {
+		return nil, err
+	}
 
 	files := make(map[string]struct{})
 	for _, name := range g.names {
@@ -292,6 +291,20 @@ func (b *TaskSet) graph() (*graph, error) {
 	return g, nil
 }
 
+// checkPrefixFree rejects path sets where one declared path contains another.
+// Outputs and final artifact paths must be prefix-free so a directory producer
+// cannot overlap a nested file producer without a deterministic dependency.
+func checkPrefixFree(kind string, owners map[string]string, paths []string) error {
+	for idx, path := range paths {
+		for _, other := range paths[idx+1:] {
+			if strings.HasPrefix(other, path+"/") {
+				return errors.Format("%s %s declared by task %s overlaps %s %s declared by task %s", kind, other, owners[other], kind, path, owners[path])
+			}
+		}
+	}
+	return nil
+}
+
 // matchProducers finds the tasks producing input path per schema.md D1.
 // Three rules are tried in order; the first rule yielding matches wins.
 func matchProducers(path string, producers map[string]string, outputs []string) []string {
@@ -330,12 +343,12 @@ func validateTask(name string, task core.Task) error {
 	if !taskNamePattern.MatchString(name) {
 		return errors.Format("invalid task name %q: must match %s", name, taskNamePattern)
 	}
-	if output := string(task.Output); output != "" && !filepath.IsLocal(output) {
-		return errors.Format("task %s: output %s: path must be relative and must not traverse outside the build directory", name, output)
+	if output := string(task.Output); output != "" && !validLocalPath(output) {
+		return errors.Format("task %s: output %s: path must be relative, must not traverse outside the build directory, and must not resolve to the build directory", name, output)
 	}
 	for _, input := range task.Inputs {
-		if !filepath.IsLocal(string(input)) {
-			return errors.Format("task %s: input %s: path must be relative and must not traverse outside the build directory", name, input)
+		if !validLocalPath(string(input)) {
+			return errors.Format("task %s: input %s: path must be relative, must not traverse outside the build directory, and must not resolve to the build directory", name, input)
 		}
 	}
 	switch task.Kind {
@@ -346,8 +359,8 @@ func validateTask(name string, task core.Task) error {
 		if task.Output == "" {
 			return errors.Format("task %s: kind %s requires an output", name, task.Kind)
 		}
-		if task.Kind == "File" && !filepath.IsLocal(string(task.File.Source)) {
-			return errors.Format("task %s: file source %s: path must be relative and must not traverse outside the component directory", name, task.File.Source)
+		if task.Kind == "File" && !validLocalPath(string(task.File.Source)) {
+			return errors.Format("task %s: file source %s: path must be relative, must not traverse outside the component directory, and must not resolve to the component directory", name, task.File.Source)
 		}
 	case "Kustomize", "Join":
 		if len(task.Inputs) < 1 {
@@ -357,8 +370,8 @@ func validateTask(name string, task core.Task) error {
 			return errors.Format("task %s: kind %s requires an output", name, task.Kind)
 		}
 		for path := range task.Kustomize.Files {
-			if !filepath.IsLocal(string(path)) {
-				return errors.Format("task %s: kustomize file %s: path must be relative and must not traverse outside the kustomize directory", name, path)
+			if !validLocalPath(string(path)) {
+				return errors.Format("task %s: kustomize file %s: path must be relative, must not traverse outside the kustomize directory, and must not resolve to the kustomize directory", name, path)
 			}
 		}
 	case "Command":
@@ -380,13 +393,17 @@ func validateTask(name string, task core.Task) error {
 		if task.Output != "" {
 			return errors.Format("task %s: kind Artifact must not declare an output", name)
 		}
-		if path := string(task.Artifact.Path); path != "" && !filepath.IsLocal(path) {
-			return errors.Format("task %s: artifact path %s: path must be relative and must not traverse outside the write-to directory", name, path)
+		if path := string(task.Artifact.Path); path != "" && !validLocalPath(path) {
+			return errors.Format("task %s: artifact path %s: path must be relative, must not traverse outside the write-to directory, and must not resolve to the write-to directory", name, path)
 		}
 	default:
 		return errors.Format("task %s: unsupported kind %s", name, task.Kind)
 	}
 	return nil
+}
+
+func validLocalPath(path string) bool {
+	return filepath.IsLocal(path) && filepath.Clean(path) != "."
 }
 
 // checkCycles runs Kahn's algorithm over the graph.  Any cycle is an error

--- a/internal/component/v1beta1/v1beta1_test.go
+++ b/internal/component/v1beta1/v1beta1_test.go
@@ -224,6 +224,18 @@ func TestBuildDuplicateOutputError(t *testing.T) {
 	assert.ErrorContains(t, err, "bravo")
 }
 
+func TestBuildOverlappingOutputError(t *testing.T) {
+	b := newTestTaskSet(t, map[string]core.Task{
+		"parent": resourcesTask("a", "out"),
+		"nested": resourcesTask("b", "out/file.yaml"),
+	})
+	err := b.Build(t.Context())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "overlaps output")
+	assert.ErrorContains(t, err, "parent")
+	assert.ErrorContains(t, err, "nested")
+}
+
 func TestBuildDuplicateArtifactPathError(t *testing.T) {
 	b := newTestTaskSet(t, map[string]core.Task{
 		"gen-a": resourcesTask("a", "a.gen.yaml"),
@@ -265,11 +277,49 @@ func TestBuildPathTraversalError(t *testing.T) {
 			errText: "must not traverse outside the write-to directory",
 		},
 		{
+			name: "ArtifactPathDot",
+			tasks: map[string]core.Task{
+				"gen": resourcesTask("a", "a.gen.yaml"),
+				"deploy": {
+					Kind:     "Artifact",
+					Inputs:   []core.FileOrDirectoryPath{"a.gen.yaml"},
+					Artifact: core.Artifact{Path: "."},
+				},
+			},
+			errText: "must not resolve to the write-to directory",
+		},
+		{
+			name: "ArtifactPathCleansToDot",
+			tasks: map[string]core.Task{
+				"gen": resourcesTask("a", "a.gen.yaml"),
+				"deploy": {
+					Kind:     "Artifact",
+					Inputs:   []core.FileOrDirectoryPath{"a.gen.yaml"},
+					Artifact: core.Artifact{Path: "out/.."},
+				},
+			},
+			errText: "must not resolve to the write-to directory",
+		},
+		{
 			name: "OutputEscapes",
 			tasks: map[string]core.Task{
 				"gen": resourcesTask("a", "../a.gen.yaml"),
 			},
 			errText: "must not traverse outside the build directory",
+		},
+		{
+			name: "OutputDot",
+			tasks: map[string]core.Task{
+				"gen": resourcesTask("a", "."),
+			},
+			errText: "must not resolve to the build directory",
+		},
+		{
+			name: "OutputCleansToDot",
+			tasks: map[string]core.Task{
+				"gen": resourcesTask("a", "out/.."),
+			},
+			errText: "must not resolve to the build directory",
 		},
 		{
 			name: "OutputAbsolute",
@@ -290,6 +340,37 @@ func TestBuildPathTraversalError(t *testing.T) {
 			errText: "must not traverse outside the build directory",
 		},
 		{
+			name: "InputDot",
+			tasks: map[string]core.Task{
+				"combine": {
+					Kind:   "Join",
+					Inputs: []core.FileOrDirectoryPath{"."},
+					Output: "combined.gen.yaml",
+				},
+			},
+			errText: "must not resolve to the build directory",
+		},
+		{
+			name: "DefaultArtifactInputDot",
+			tasks: map[string]core.Task{
+				"deploy": {
+					Kind:   "Artifact",
+					Inputs: []core.FileOrDirectoryPath{"."},
+				},
+			},
+			errText: "must not resolve to the build directory",
+		},
+		{
+			name: "DefaultArtifactInputCleansToDot",
+			tasks: map[string]core.Task{
+				"deploy": {
+					Kind:   "Artifact",
+					Inputs: []core.FileOrDirectoryPath{"out/.."},
+				},
+			},
+			errText: "must not resolve to the build directory",
+		},
+		{
 			name: "FileSourceEscapes",
 			tasks: map[string]core.Task{
 				"gen": {
@@ -299,6 +380,17 @@ func TestBuildPathTraversalError(t *testing.T) {
 				},
 			},
 			errText: "must not traverse outside the component directory",
+		},
+		{
+			name: "FileSourceDot",
+			tasks: map[string]core.Task{
+				"gen": {
+					Kind:   "File",
+					File:   core.File{Source: "."},
+					Output: "a.gen.yaml",
+				},
+			},
+			errText: "must not resolve to the component directory",
 		},
 		{
 			name: "KustomizeFileEscapes",
@@ -314,6 +406,21 @@ func TestBuildPathTraversalError(t *testing.T) {
 				},
 			},
 			errText: "must not traverse outside the kustomize directory",
+		},
+		{
+			name: "KustomizeFileDot",
+			tasks: map[string]core.Task{
+				"gen": resourcesTask("a", "a.gen.yaml"),
+				"transform": {
+					Kind:   "Kustomize",
+					Inputs: []core.FileOrDirectoryPath{"a.gen.yaml"},
+					Output: "out.gen.yaml",
+					Kustomize: core.Kustomize{
+						Files: core.FileContentMap{".": "data"},
+					},
+				},
+			},
+			errText: "must not resolve to the kustomize directory",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/component/v1beta1/v1beta1_test.go
+++ b/internal/component/v1beta1/v1beta1_test.go
@@ -360,6 +360,98 @@ func TestBuildSharedCommandInputs(t *testing.T) {
 	}
 }
 
+func TestBuildOverlappingArtifactPathError(t *testing.T) {
+	b := newTestTaskSet(t, map[string]core.Task{
+		"gen-a": resourcesTask("a", "a.gen.yaml"),
+		"gen-b": resourcesTask("b", "b.gen.yaml"),
+		"deploy-dir": {
+			Kind:     "Artifact",
+			Inputs:   []core.FileOrDirectoryPath{"a.gen.yaml"},
+			Artifact: core.Artifact{Path: "components/vault"},
+		},
+		"deploy-file": {
+			Kind:     "Artifact",
+			Inputs:   []core.FileOrDirectoryPath{"b.gen.yaml"},
+			Artifact: core.Artifact{Path: "components/vault/rbac.yaml"},
+		},
+	})
+	err := b.Build(t.Context())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "overlaps artifact path")
+	assert.ErrorContains(t, err, "deploy-dir")
+	assert.ErrorContains(t, err, "deploy-file")
+}
+
+func TestBuildOverlappingComponentInputs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test depends on the true command")
+	}
+	// One task consumes the base directory while another consumes a file
+	// under it.  The preload must not fail on the write-once store.
+	b := newTestTaskSet(t, map[string]core.Task{
+		"validate": {
+			Kind:    "Command",
+			Inputs:  []core.FileOrDirectoryPath{"base"},
+			Command: core.Command{Args: []string{"true"}},
+		},
+		"combine-file": {
+			Kind:   "Join",
+			Inputs: []core.FileOrDirectoryPath{"base/patch.yaml"},
+			Output: "file.gen.yaml",
+		},
+	})
+	dir := filepath.Join(b.Opts.AbsLeaf(), "base")
+	require.NoError(t, os.MkdirAll(dir, 0o777))
+	want := "greeting: hello\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "patch.yaml"), []byte(want), 0o666))
+
+	require.NoError(t, b.Build(t.Context()))
+
+	data, ok := b.Opts.Store.Get("file.gen.yaml")
+	require.True(t, ok)
+	assert.Equal(t, want, string(data))
+}
+
+func TestBuildArtifactReplacesStaleFiles(t *testing.T) {
+	newDirTaskSet := func(t *testing.T, artifactPath string) *TaskSet {
+		b := newTestTaskSet(t, map[string]core.Task{
+			"deploy": {
+				Kind:     "Artifact",
+				Inputs:   []core.FileOrDirectoryPath{"manifests"},
+				Artifact: core.Artifact{Path: core.FileOrDirectoryPath(artifactPath)},
+			},
+		})
+		dir := filepath.Join(b.Opts.AbsLeaf(), "manifests")
+		require.NoError(t, os.MkdirAll(dir, 0o777))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "real.yaml"), []byte("real: true\n"), 0o666))
+		return b
+	}
+
+	for _, tc := range []struct {
+		name string
+		path string
+		dest string
+	}{
+		{name: "DefaultPath", path: "", dest: "manifests"},
+		{name: "RenamedPath", path: "out", dest: "out"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b := newDirTaskSet(t, tc.path)
+			// Simulate a stale file from a previous render.
+			staleDir := filepath.Join(b.Opts.AbsWriteTo(), tc.dest)
+			require.NoError(t, os.MkdirAll(staleDir, 0o777))
+			require.NoError(t, os.WriteFile(filepath.Join(staleDir, "stale.yaml"), []byte("stale: true\n"), 0o666))
+
+			require.NoError(t, b.Build(t.Context()))
+
+			_, err := os.Stat(filepath.Join(staleDir, "real.yaml"))
+			assert.NoError(t, err, "expected current file to be written")
+			_, err = os.Stat(filepath.Join(staleDir, "stale.yaml"))
+			assert.True(t, os.IsNotExist(err), "expected stale file to be removed")
+		})
+	}
+}
+
 func TestBuildDisabledNoOp(t *testing.T) {
 	b := newTestTaskSet(t, map[string]core.Task{
 		"gen": resourcesTask("a", "a.gen.yaml"),

--- a/internal/component/v1beta1/v1beta1_test.go
+++ b/internal/component/v1beta1/v1beta1_test.go
@@ -1,0 +1,624 @@
+package v1beta1
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"cuelang.org/go/cue/cuecontext"
+	core "github.com/holos-run/holos/api/core/v1beta1"
+	"github.com/holos-run/holos/internal/holos"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestTaskSet returns a TaskSet over hand-built tasks with a temp platform
+// root containing an empty component directory at components/test.
+func newTestTaskSet(t *testing.T, tasks map[string]core.Task) *TaskSet {
+	t.Helper()
+	root := t.TempDir()
+	leaf := filepath.Join("components", "test")
+	require.NoError(t, os.MkdirAll(filepath.Join(root, leaf), 0o777))
+	opts := holos.NewBuildOpts(root, leaf, "deploy", t.TempDir())
+	return &TaskSet{
+		TaskSet: core.TaskSet{
+			APIVersion: "v1beta1",
+			Kind:       "TaskSet",
+			Metadata:   core.Metadata{Name: "test"},
+			Spec:       core.TaskSetSpec{Tasks: tasks},
+		},
+		Opts: opts,
+	}
+}
+
+// resourcesTask returns a Resources task producing output with one ConfigMap
+// named name.
+func resourcesTask(name string, output string) core.Task {
+	return core.Task{
+		Kind:   "Resources",
+		Output: core.FileOrDirectoryPath(output),
+		Resources: core.Resources{
+			"ConfigMap": {
+				core.InternalLabel(name): core.Resource{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata":   map[string]any{"name": name},
+				},
+			},
+		},
+	}
+}
+
+// recordOrder wires a runHook recording the order tasks start in while still
+// executing the real task bodies.
+func recordOrder(b *TaskSet) *[]string {
+	var mu sync.Mutex
+	order := &[]string{}
+	b.runHook = func(ctx context.Context, name string, run func(context.Context) error) error {
+		mu.Lock()
+		*order = append(*order, name)
+		mu.Unlock()
+		return run(ctx)
+	}
+	return order
+}
+
+func indexOf(t *testing.T, order []string, name string) int {
+	t.Helper()
+	for idx, val := range order {
+		if val == name {
+			return idx
+		}
+	}
+	t.Fatalf("task %s not found in order %v", name, order)
+	return -1
+}
+
+func TestBuildLinearChain(t *testing.T) {
+	b := newTestTaskSet(t, map[string]core.Task{
+		"gen": resourcesTask("a", "resources.gen.yaml"),
+		"combine": {
+			Kind:   "Join",
+			Inputs: []core.FileOrDirectoryPath{"resources.gen.yaml"},
+			Output: "combined.gen.yaml",
+		},
+		"deploy": {
+			Kind:   "Artifact",
+			Inputs: []core.FileOrDirectoryPath{"combined.gen.yaml"},
+		},
+	})
+	order := recordOrder(b)
+
+	require.NoError(t, b.Build(t.Context()))
+
+	assert.Less(t, indexOf(t, *order, "gen"), indexOf(t, *order, "combine"))
+	assert.Less(t, indexOf(t, *order, "combine"), indexOf(t, *order, "deploy"))
+
+	data, err := os.ReadFile(filepath.Join(b.Opts.AbsWriteTo(), "combined.gen.yaml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "kind: ConfigMap")
+}
+
+func TestBuildDiamondDependency(t *testing.T) {
+	b := newTestTaskSet(t, map[string]core.Task{
+		"gen": resourcesTask("a", "a.gen.yaml"),
+		"left": {
+			Kind:   "Join",
+			Inputs: []core.FileOrDirectoryPath{"a.gen.yaml"},
+			Output: "left.gen.yaml",
+		},
+		"right": {
+			Kind:   "Join",
+			Inputs: []core.FileOrDirectoryPath{"a.gen.yaml"},
+			Output: "right.gen.yaml",
+		},
+		"merge": {
+			Kind:   "Join",
+			Inputs: []core.FileOrDirectoryPath{"left.gen.yaml", "right.gen.yaml"},
+			Join:   core.Join{Separator: "---\n"},
+			Output: "merge.gen.yaml",
+		},
+		"deploy": {
+			Kind:     "Artifact",
+			Inputs:   []core.FileOrDirectoryPath{"merge.gen.yaml"},
+			Artifact: core.Artifact{Path: "components/test/merge.gen.yaml"},
+		},
+	})
+	order := recordOrder(b)
+
+	require.NoError(t, b.Build(t.Context()))
+
+	gen := indexOf(t, *order, "gen")
+	merge := indexOf(t, *order, "merge")
+	assert.Less(t, gen, indexOf(t, *order, "left"))
+	assert.Less(t, gen, indexOf(t, *order, "right"))
+	assert.Less(t, indexOf(t, *order, "left"), merge)
+	assert.Less(t, indexOf(t, *order, "right"), merge)
+	assert.Less(t, merge, indexOf(t, *order, "deploy"))
+
+	data, err := os.ReadFile(filepath.Join(b.Opts.AbsWriteTo(), "components", "test", "merge.gen.yaml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "---\n")
+}
+
+func TestBuildCycleError(t *testing.T) {
+	b := newTestTaskSet(t, map[string]core.Task{
+		"alfa": {
+			Kind:    "Command",
+			Inputs:  []core.FileOrDirectoryPath{"bravo.gen.yaml"},
+			Output:  "alfa.gen.yaml",
+			Command: core.Command{Args: []string{"true"}},
+		},
+		"bravo": {
+			Kind:    "Command",
+			Inputs:  []core.FileOrDirectoryPath{"alfa.gen.yaml"},
+			Output:  "bravo.gen.yaml",
+			Command: core.Command{Args: []string{"true"}},
+		},
+	})
+	err := b.Build(t.Context())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "cycle detected")
+	assert.ErrorContains(t, err, "alfa")
+	assert.ErrorContains(t, err, "bravo")
+}
+
+func TestBuildUnknownInputError(t *testing.T) {
+	b := newTestTaskSet(t, map[string]core.Task{
+		"combine": {
+			Kind:   "Join",
+			Inputs: []core.FileOrDirectoryPath{"nope.gen.yaml"},
+			Output: "combined.gen.yaml",
+		},
+	})
+	err := b.Build(t.Context())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "task combine")
+	assert.ErrorContains(t, err, "nope.gen.yaml")
+	assert.ErrorContains(t, err, "matches no task output")
+}
+
+func TestBuildUnknownDependsOnError(t *testing.T) {
+	b := newTestTaskSet(t, map[string]core.Task{
+		"gen": func() core.Task {
+			task := resourcesTask("a", "a.gen.yaml")
+			task.DependsOn = map[string]core.Dependency{"missing": {}}
+			return task
+		}(),
+	})
+	err := b.Build(t.Context())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "task gen")
+	assert.ErrorContains(t, err, "missing")
+	assert.ErrorContains(t, err, "no such task")
+}
+
+func TestBuildCanonicalDependsOnError(t *testing.T) {
+	b := newTestTaskSet(t, map[string]core.Task{
+		"gen": func() core.Task {
+			task := resourcesTask("a", "a.gen.yaml")
+			task.DependsOn = map[string]core.Dependency{"components/vault:helm": {}}
+			return task
+		}(),
+	})
+	err := b.Build(t.Context())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "canonical task ids are not supported")
+}
+
+func TestBuildDuplicateOutputError(t *testing.T) {
+	b := newTestTaskSet(t, map[string]core.Task{
+		"alfa":  resourcesTask("a", "same.gen.yaml"),
+		"bravo": resourcesTask("b", "same.gen.yaml"),
+	})
+	err := b.Build(t.Context())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "duplicate output same.gen.yaml")
+	assert.ErrorContains(t, err, "alfa")
+	assert.ErrorContains(t, err, "bravo")
+}
+
+func TestBuildDisabledNoOp(t *testing.T) {
+	b := newTestTaskSet(t, map[string]core.Task{
+		"gen": resourcesTask("a", "a.gen.yaml"),
+		"deploy": {
+			Kind:   "Artifact",
+			Inputs: []core.FileOrDirectoryPath{"a.gen.yaml"},
+		},
+	})
+	b.Spec.Disabled = true
+	order := recordOrder(b)
+
+	require.NoError(t, b.Build(t.Context()))
+
+	assert.Empty(t, *order, "expected no tasks to run for a disabled TaskSet")
+	_, err := os.Stat(filepath.Join(b.Opts.AbsWriteTo(), "a.gen.yaml"))
+	assert.True(t, os.IsNotExist(err), "expected no artifact to be written")
+}
+
+func TestBuildDependsOnOrdering(t *testing.T) {
+	second := resourcesTask("b", "b.gen.yaml")
+	second.DependsOn = map[string]core.Dependency{"first": {}}
+	b := newTestTaskSet(t, map[string]core.Task{
+		"first":  resourcesTask("a", "a.gen.yaml"),
+		"second": second,
+	})
+	b.Opts.Concurrency = 1
+	order := recordOrder(b)
+
+	require.NoError(t, b.Build(t.Context()))
+
+	assert.Less(t, indexOf(t, *order, "first"), indexOf(t, *order, "second"))
+}
+
+func TestBuildComponentDirectoryInput(t *testing.T) {
+	b := newTestTaskSet(t, map[string]core.Task{
+		"combine": {
+			Kind:   "Join",
+			Inputs: []core.FileOrDirectoryPath{"input.yaml"},
+			Output: "combined.gen.yaml",
+		},
+		"deploy": {
+			Kind:   "Artifact",
+			Inputs: []core.FileOrDirectoryPath{"combined.gen.yaml"},
+		},
+	})
+	want := "greeting: hello\n"
+	path := filepath.Join(b.Opts.AbsLeaf(), "input.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(want), 0o666))
+
+	require.NoError(t, b.Build(t.Context()))
+
+	data, err := os.ReadFile(filepath.Join(b.Opts.AbsWriteTo(), "combined.gen.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, want, string(data))
+}
+
+func TestBuildDeterministicReadyOrder(t *testing.T) {
+	tasks := make(map[string]core.Task)
+	names := []string{"alfa", "bravo", "charlie", "delta", "echo"}
+	for _, name := range names {
+		tasks[name] = resourcesTask(name, name+".gen.yaml")
+	}
+	// Repeat the build to guard against map iteration order masking a bug.
+	for i := 0; i < 5; i++ {
+		b := newTestTaskSet(t, tasks)
+		b.Opts.Concurrency = 1
+		order := recordOrder(b)
+		require.NoError(t, b.Build(t.Context()))
+		assert.Equal(t, names, *order, "expected ready tasks to run in sorted name order")
+	}
+}
+
+func TestBuildConcurrencyBound(t *testing.T) {
+	tasks := make(map[string]core.Task)
+	for _, name := range []string{"alfa", "bravo", "charlie", "delta", "echo", "foxtrot"} {
+		tasks[name] = resourcesTask(name, name+".gen.yaml")
+	}
+
+	track := func(b *TaskSet) *int {
+		var mu sync.Mutex
+		var current int
+		maxSeen := new(int)
+		b.runHook = func(ctx context.Context, name string, run func(context.Context) error) error {
+			mu.Lock()
+			current++
+			if current > *maxSeen {
+				*maxSeen = current
+			}
+			mu.Unlock()
+			time.Sleep(20 * time.Millisecond)
+			mu.Lock()
+			current--
+			mu.Unlock()
+			return nil
+		}
+		return maxSeen
+	}
+
+	t.Run("Bounded", func(t *testing.T) {
+		b := newTestTaskSet(t, tasks)
+		b.Opts.Concurrency = 2
+		maxSeen := track(b)
+		require.NoError(t, b.Build(t.Context()))
+		assert.LessOrEqual(t, *maxSeen, 2, "expected at most 2 tasks in flight")
+		assert.GreaterOrEqual(t, *maxSeen, 2, "expected independent tasks to run concurrently")
+	})
+
+	t.Run("Sequential", func(t *testing.T) {
+		b := newTestTaskSet(t, tasks)
+		b.Opts.Concurrency = 1
+		maxSeen := track(b)
+		require.NoError(t, b.Build(t.Context()))
+		assert.Equal(t, 1, *maxSeen, "expected exactly 1 task in flight")
+	})
+
+	t.Run("ZeroDefaultsToOne", func(t *testing.T) {
+		b := newTestTaskSet(t, tasks)
+		b.Opts.Concurrency = 0
+		maxSeen := track(b)
+		require.NoError(t, b.Build(t.Context()))
+		assert.Equal(t, 1, *maxSeen, "expected exactly 1 task in flight")
+	})
+}
+
+func TestBuildTaskFailureStopsBuild(t *testing.T) {
+	b := newTestTaskSet(t, map[string]core.Task{
+		"gen": {
+			Kind:   "File",
+			File:   core.File{Source: "does-not-exist.yaml"},
+			Output: "a.gen.yaml",
+		},
+		"deploy": {
+			Kind:   "Artifact",
+			Inputs: []core.FileOrDirectoryPath{"a.gen.yaml"},
+		},
+	})
+	order := recordOrder(b)
+
+	err := b.Build(t.Context())
+	require.Error(t, err)
+	assert.NotContains(t, *order, "deploy", "expected downstream task to be skipped on failure")
+}
+
+func TestBuildCommandStdin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test depends on the cat command")
+	}
+	b := newTestTaskSet(t, map[string]core.Task{
+		"gen": resourcesTask("a", "a.gen.yaml"),
+		"copy": {
+			Kind:   "Command",
+			Inputs: []core.FileOrDirectoryPath{"a.gen.yaml"},
+			Output: "copy.gen.yaml",
+			Command: core.Command{
+				Args:           []string{"cat"},
+				Stdin:          "a.gen.yaml",
+				IsStdoutOutput: true,
+			},
+		},
+		"deploy": {
+			Kind:   "Artifact",
+			Inputs: []core.FileOrDirectoryPath{"copy.gen.yaml"},
+		},
+	})
+
+	require.NoError(t, b.Build(t.Context()))
+
+	want, ok := b.Opts.Store.Get("a.gen.yaml")
+	require.True(t, ok)
+	data, err := os.ReadFile(filepath.Join(b.Opts.AbsWriteTo(), "copy.gen.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, string(want), string(data))
+}
+
+func TestBuildCommandValidator(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test depends on the false command")
+	}
+	// A command with only inputs validates, gating downstream tasks through
+	// dependsOn edges (schema.md D2).
+	deploy := core.Task{
+		Kind:      "Artifact",
+		Inputs:    []core.FileOrDirectoryPath{"a.gen.yaml"},
+		DependsOn: map[string]core.Dependency{"validate": {}},
+	}
+
+	t.Run("Pass", func(t *testing.T) {
+		b := newTestTaskSet(t, map[string]core.Task{
+			"gen": resourcesTask("a", "a.gen.yaml"),
+			"validate": {
+				Kind:    "Command",
+				Inputs:  []core.FileOrDirectoryPath{"a.gen.yaml"},
+				Command: core.Command{Args: []string{"true"}},
+			},
+			"deploy": deploy,
+		})
+		require.NoError(t, b.Build(t.Context()))
+		_, err := os.Stat(filepath.Join(b.Opts.AbsWriteTo(), "a.gen.yaml"))
+		assert.NoError(t, err, "expected artifact written after validation passed")
+	})
+
+	t.Run("Fail", func(t *testing.T) {
+		b := newTestTaskSet(t, map[string]core.Task{
+			"gen": resourcesTask("a", "a.gen.yaml"),
+			"validate": {
+				Kind:    "Command",
+				Inputs:  []core.FileOrDirectoryPath{"a.gen.yaml"},
+				Command: core.Command{Args: []string{"false"}},
+			},
+			"deploy": deploy,
+		})
+		err := b.Build(t.Context())
+		require.Error(t, err)
+		_, statErr := os.Stat(filepath.Join(b.Opts.AbsWriteTo(), "a.gen.yaml"))
+		assert.True(t, os.IsNotExist(statErr), "expected no artifact written after validation failed")
+	})
+}
+
+func TestMatchProducers(t *testing.T) {
+	producers := map[string]string{
+		"a.gen.yaml":       "alfa",
+		"out/one.yaml":     "bravo",
+		"out/two.yaml":     "charlie",
+		"manifests":        "delta",
+		"other/three.yaml": "echo",
+	}
+	outputs := []string{"a.gen.yaml", "manifests", "other/three.yaml", "out/one.yaml", "out/two.yaml"}
+
+	for _, tc := range []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{name: "ExactMatch", input: "a.gen.yaml", want: []string{"alfa"}},
+		{name: "DirectoryInput", input: "out", want: []string{"bravo", "charlie"}},
+		{name: "DirectoryOutput", input: "manifests/deep/file.yaml", want: []string{"delta"}},
+		{name: "NoMatch", input: "missing.yaml", want: nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, matchProducers(tc.input, producers, outputs))
+		})
+	}
+}
+
+func TestValidateTask(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		task    core.Task
+		errText string
+	}{
+		{
+			name:    "InvalidName",
+			task:    core.Task{Kind: "Resources", Output: "a.yaml"},
+			errText: "invalid task name",
+		},
+		{
+			name:    "UnsupportedKind",
+			task:    core.Task{Kind: "Bogus"},
+			errText: "unsupported kind Bogus",
+		},
+		{
+			name:    "HelmWithInputs",
+			task:    core.Task{Kind: "Helm", Inputs: []core.FileOrDirectoryPath{"a.yaml"}, Output: "b.yaml"},
+			errText: "must not declare inputs",
+		},
+		{
+			name:    "ResourcesWithoutOutput",
+			task:    core.Task{Kind: "Resources"},
+			errText: "requires an output",
+		},
+		{
+			name:    "JoinWithoutInputs",
+			task:    core.Task{Kind: "Join", Output: "a.yaml"},
+			errText: "requires at least one input",
+		},
+		{
+			name:    "CommandWithoutArgs",
+			task:    core.Task{Kind: "Command"},
+			errText: "args length must be at least 1",
+		},
+		{
+			name: "CommandStdoutWithoutOutput",
+			task: core.Task{
+				Kind:    "Command",
+				Command: core.Command{Args: []string{"true"}, IsStdoutOutput: true},
+			},
+			errText: "requires an output when isStdoutOutput",
+		},
+		{
+			name: "CommandStdinNotDeclared",
+			task: core.Task{
+				Kind:    "Command",
+				Command: core.Command{Args: []string{"cat"}, Stdin: "a.yaml"},
+			},
+			errText: "must be one of the task inputs",
+		},
+		{
+			name:    "ArtifactTwoInputs",
+			task:    core.Task{Kind: "Artifact", Inputs: []core.FileOrDirectoryPath{"a.yaml", "b.yaml"}},
+			errText: "exactly one input",
+		},
+		{
+			name:    "ArtifactWithOutput",
+			task:    core.Task{Kind: "Artifact", Inputs: []core.FileOrDirectoryPath{"a.yaml"}, Output: "b.yaml"},
+			errText: "must not declare an output",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			name := "valid-name"
+			if tc.name == "InvalidName" {
+				name = "Invalid_Name"
+			}
+			err := validateTask(name, tc.task)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tc.errText)
+		})
+	}
+
+	t.Run("Valid", func(t *testing.T) {
+		err := validateTask("valid-name", core.Task{Kind: "Resources", Output: "a.yaml"})
+		assert.NoError(t, err)
+	})
+}
+
+func TestLoad(t *testing.T) {
+	cuectx := cuecontext.New()
+
+	t.Run("Valid", func(t *testing.T) {
+		v := cuectx.CompileString(`{
+			apiVersion: "v1beta1"
+			kind: "TaskSet"
+			metadata: name: "test"
+			spec: tasks: gen: {
+				kind: "Resources"
+				output: "a.gen.yaml"
+				resources: {}
+			}
+			buildContext: {
+				tempDir: "/tmp/holos"
+				rootDir: "/platform"
+				leafDir: "components/test"
+				holosExecutable: "holos"
+			}
+		}`)
+		var b TaskSet
+		require.NoError(t, b.Load(v))
+		assert.Equal(t, "test", b.Metadata.Name)
+		assert.Equal(t, "Resources", b.Spec.Tasks["gen"].Kind)
+	})
+
+	t.Run("NotConcrete", func(t *testing.T) {
+		v := cuectx.CompileString(`{
+			apiVersion: "v1beta1"
+			kind: "TaskSet"
+			metadata: name: string
+			spec: tasks: {}
+			buildContext: {
+				tempDir: "/tmp/holos"
+				rootDir: "/platform"
+				leafDir: "components/test"
+				holosExecutable: "holos"
+			}
+		}`)
+		var b TaskSet
+		assert.Error(t, b.Load(v))
+	})
+}
+
+func TestExport(t *testing.T) {
+	b := newTestTaskSet(t, map[string]core.Task{
+		"gen": resourcesTask("a", "a.gen.yaml"),
+	})
+	var buf bytes.Buffer
+	encoder, err := holos.NewSequentialEncoder("yaml", &buf)
+	require.NoError(t, err)
+	require.NoError(t, b.Export(0, encoder))
+	require.NoError(t, encoder.Close())
+	assert.Contains(t, buf.String(), "kind: TaskSet")
+	assert.Contains(t, buf.String(), "apiVersion: v1beta1")
+}
+
+func TestBuildContextTags(t *testing.T) {
+	root := t.TempDir()
+	opts := holos.NewBuildOpts(root, "components/test", "deploy", t.TempDir())
+	bc, err := NewBuildContext(opts)
+	require.NoError(t, err)
+	tags, err := bc.Tags()
+	require.NoError(t, err)
+	require.Len(t, tags, 1)
+	assert.Contains(t, tags[0], fmt.Sprintf("%s=", core.BuildContextTag))
+	assert.Contains(t, tags[0], root)
+
+	t.Run("RelativeRootError", func(t *testing.T) {
+		opts := holos.NewBuildOpts("relative/root", "components/test", "deploy", t.TempDir())
+		_, err := NewBuildContext(opts)
+		assert.Error(t, err)
+	})
+}

--- a/internal/component/v1beta1/v1beta1_test.go
+++ b/internal/component/v1beta1/v1beta1_test.go
@@ -224,6 +224,142 @@ func TestBuildDuplicateOutputError(t *testing.T) {
 	assert.ErrorContains(t, err, "bravo")
 }
 
+func TestBuildDuplicateArtifactPathError(t *testing.T) {
+	b := newTestTaskSet(t, map[string]core.Task{
+		"gen-a": resourcesTask("a", "a.gen.yaml"),
+		"gen-b": resourcesTask("b", "b.gen.yaml"),
+		"deploy-a": {
+			Kind:     "Artifact",
+			Inputs:   []core.FileOrDirectoryPath{"a.gen.yaml"},
+			Artifact: core.Artifact{Path: "same.gen.yaml"},
+		},
+		"deploy-b": {
+			Kind:     "Artifact",
+			Inputs:   []core.FileOrDirectoryPath{"b.gen.yaml"},
+			Artifact: core.Artifact{Path: "same.gen.yaml"},
+		},
+	})
+	err := b.Build(t.Context())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "duplicate artifact path same.gen.yaml")
+	assert.ErrorContains(t, err, "deploy-a")
+	assert.ErrorContains(t, err, "deploy-b")
+}
+
+func TestBuildPathTraversalError(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		tasks   map[string]core.Task
+		errText string
+	}{
+		{
+			name: "ArtifactPathEscapes",
+			tasks: map[string]core.Task{
+				"gen": resourcesTask("a", "a.gen.yaml"),
+				"deploy": {
+					Kind:     "Artifact",
+					Inputs:   []core.FileOrDirectoryPath{"a.gen.yaml"},
+					Artifact: core.Artifact{Path: "../escape.yaml"},
+				},
+			},
+			errText: "must not traverse outside the write-to directory",
+		},
+		{
+			name: "OutputEscapes",
+			tasks: map[string]core.Task{
+				"gen": resourcesTask("a", "../a.gen.yaml"),
+			},
+			errText: "must not traverse outside the build directory",
+		},
+		{
+			name: "OutputAbsolute",
+			tasks: map[string]core.Task{
+				"gen": resourcesTask("a", "/tmp/a.gen.yaml"),
+			},
+			errText: "must not traverse outside the build directory",
+		},
+		{
+			name: "InputEscapes",
+			tasks: map[string]core.Task{
+				"combine": {
+					Kind:   "Join",
+					Inputs: []core.FileOrDirectoryPath{"../secret.yaml"},
+					Output: "combined.gen.yaml",
+				},
+			},
+			errText: "must not traverse outside the build directory",
+		},
+		{
+			name: "FileSourceEscapes",
+			tasks: map[string]core.Task{
+				"gen": {
+					Kind:   "File",
+					File:   core.File{Source: "../../etc/passwd"},
+					Output: "a.gen.yaml",
+				},
+			},
+			errText: "must not traverse outside the component directory",
+		},
+		{
+			name: "KustomizeFileEscapes",
+			tasks: map[string]core.Task{
+				"gen": resourcesTask("a", "a.gen.yaml"),
+				"transform": {
+					Kind:   "Kustomize",
+					Inputs: []core.FileOrDirectoryPath{"a.gen.yaml"},
+					Output: "out.gen.yaml",
+					Kustomize: core.Kustomize{
+						Files: core.FileContentMap{"../patch.yaml": "data"},
+					},
+				},
+			},
+			errText: "must not traverse outside the kustomize directory",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b := newTestTaskSet(t, tc.tasks)
+			err := b.Build(t.Context())
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tc.errText)
+		})
+	}
+}
+
+func TestBuildSharedCommandInputs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test depends on the cat command")
+	}
+	// Multiple concurrent command tasks consuming the same input must not
+	// race materializing it into the shared build temp directory.
+	tasks := map[string]core.Task{
+		"gen": resourcesTask("a", "a.gen.yaml"),
+	}
+	for _, name := range []string{"alfa", "bravo", "charlie", "delta"} {
+		tasks[name] = core.Task{
+			Kind:   "Command",
+			Inputs: []core.FileOrDirectoryPath{"a.gen.yaml"},
+			Output: core.FileOrDirectoryPath(name + ".gen.yaml"),
+			Command: core.Command{
+				Args:           []string{"cat"},
+				Stdin:          "a.gen.yaml",
+				IsStdoutOutput: true,
+			},
+		}
+	}
+	b := newTestTaskSet(t, tasks)
+	b.Opts.Concurrency = 4
+
+	require.NoError(t, b.Build(t.Context()))
+
+	want, ok := b.Opts.Store.Get("a.gen.yaml")
+	require.True(t, ok)
+	for _, name := range []string{"alfa", "bravo", "charlie", "delta"} {
+		have, ok := b.Opts.Store.Get(name + ".gen.yaml")
+		require.True(t, ok)
+		assert.Equal(t, string(want), string(have))
+	}
+}
+
 func TestBuildDisabledNoOp(t *testing.T) {
 	b := newTestTaskSet(t, map[string]core.Task{
 		"gen": resourcesTask("a", "a.gen.yaml"),


### PR DESCRIPTION
## Summary
- Add `internal/component/v1beta1/v1beta1.go`: a single-component TaskSet execution engine satisfying the `holos.BuildPlan` interface (`Load`, `Build`, `Export`), asserted with `var _ holos.BuildPlan = &TaskSet{}`.
- Derive DAG edges per `doc/design/v1beta1/schema.md` D1: exact output match, directory-input prefix match, and directory-output containment, unioned with explicit `dependsOn` edges. Unknown inputs, unknown `dependsOn` targets, duplicate outputs, and cycles are errors naming the offending tasks (cycles report the full cycle path).
- Execute tasks with Kahn's algorithm on an errgroup bounded by `max(1, Opts.Concurrency)`; the ready queue is kept sorted by task name so dispatch order is deterministic.
- Port all six v1alpha6 task bodies (Resources, Helm, File, Kustomize, Join, Command) adjusting only the config source to `core.Task`; helm keeps the identical per-version `vendor/{version}` cache path and mkdir-based `onceWithLock` semantics.
- `Command` is a first-class task kind with stdin wiring (`command.stdin` must name a declared input) and DAG participation via `inputs`/`output`; a command with only inputs validates and gates downstream tasks per D2.
- Add the `Artifact` sink kind writing its single input to the write-to directory per schema.md D2, supporting both file and directory artifacts with an optional rename via `artifact.path`.
- Provide `NewBuildContext(opts)` and `Tags()` mirroring the v1alpha6 build-context tag injection through `core.BuildContextTag`.
- Inputs matching no task output are loaded from the component directory into the artifact store per D1, or fail with an error naming the task and path.
- Unit tests cover: linear chain, diamond dependency, cycle error, unknown-input error, unknown/canonical `dependsOn` errors, duplicate-output error, disabled TaskSet no-op, deterministic ready order, concurrency bounding, command stdin wiring, validator gating (pass and fail), component-directory inputs, per-kind validation, Load/Export, and build-context tags.

This package is not yet reachable from the CLI; typemeta dispatch lands in HOL-1512.

Fixes HOL-1510

## Test plan
- [x] `go test -race ./internal/component/v1beta1/` passes
- [x] `make lint` passes
- [x] `make test` passes