### PR TITLE
generate: v1beta1 typemeta scaffolding and init platform templates

### DIFF
--- a/internal/component/platform/components/v1beta1/typemeta.cue
+++ b/internal/component/platform/components/v1beta1/typemeta.cue
@@ -1,0 +1,11 @@
+@extern(embed)
+package holos
+
+import "encoding/json"
+
+holos: _ @embed(file=typemeta.yaml)
+
+holos: {
+  _buildContext: string | *"{}" @tag(holos_build_context, type=string)
+  buildContext: json.Unmarshal(_buildContext)
+}

--- a/internal/component/platform/components/v1beta1/typemeta.yaml
+++ b/internal/component/platform/components/v1beta1/typemeta.yaml
@@ -1,0 +1,2 @@
+apiVersion: v1beta1
+kind: TaskSet

--- a/internal/generate/platforms/cue.mod/pkg/github.com/holos-run/holos/api/author/v1beta1/definitions.cue
+++ b/internal/generate/platforms/cue.mod/pkg/github.com/holos-run/holos/api/author/v1beta1/definitions.cue
@@ -39,12 +39,17 @@ import (
 
 // _TaskName converts a component directory file path into a valid task name.
 // Task names must be RFC 1123 labels per
-// doc/design/v1beta1/schema.md#d3-task-naming-and-namespacing.  Use the
-// ComponentConfig Tasks field directly for sources this conversion cannot
-// make valid.
+// doc/design/v1beta1/schema.md#d3-task-naming-and-namespacing.  The out field
+// is defined only when the converted name matches the RFC 1123 pattern, so a
+// source path this conversion cannot make valid fails evaluation immediately
+// (undefined field: out) instead of producing an invalid task name.  Use the
+// ComponentConfig Tasks field directly for such sources.
 _TaskName: {
-	IN:  string
-	out: strings.ToLower(strings.Replace(strings.Replace(strings.Replace(IN, "/", "-", -1), ".", "-", -1), "_", "-", -1))
+	IN:   string
+	_out: strings.ToLower(strings.Replace(strings.Replace(strings.Replace(IN, "/", "-", -1), ".", "-", -1), "_", "-", -1))
+	if _out =~ "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$" {
+		out: _out
+	}
 }
 
 // Kustomize and Kubernetes are identical.

--- a/internal/generate/platforms/cue.mod/pkg/github.com/holos-run/holos/api/author/v1beta1/definitions.cue
+++ b/internal/generate/platforms/cue.mod/pkg/github.com/holos-run/holos/api/author/v1beta1/definitions.cue
@@ -1,0 +1,199 @@
+// Hand-written assembly CUE for the author v1beta1 package.  The generated
+// definitions in cue.mod/gen define types only; this file fills
+// TaskSet.spec.tasks from the author wrapper fields per the design doc
+// doc/design/v1beta1/schema.md.  Mirrors the v1alpha6 sibling, replacing the
+// BuildPlan artifact/generator/transformer lists with struct-keyed tasks.
+package author
+
+import (
+	"strings"
+
+	ks "sigs.k8s.io/kustomize/api/types"
+	core "github.com/holos-run/holos/api/core/v1beta1:core"
+)
+
+#Platform: {
+	name:       _
+	components: _
+	resource: {
+		metadata: "name": name
+		spec: "components": [for x in components {x}]
+	}
+}
+
+#KustomizeConfig: {
+	CommonLabels: _
+	Kustomization: ks.#Kustomization & {
+		apiVersion: "kustomize.config.k8s.io/v1beta1"
+		kind:       "Kustomization"
+		_labels: {}
+		if len(CommonLabels) > 0 {
+			_labels: commonLabels: {
+				includeSelectors: false
+				pairs:            CommonLabels
+			}
+			labels: [for x in _labels {x}]
+		}
+	}
+}
+
+// _TaskName converts a component directory file path into a valid task name.
+// Task names must be RFC 1123 labels per
+// doc/design/v1beta1/schema.md#d3-task-naming-and-namespacing.  Use the
+// ComponentConfig Tasks field directly for sources this conversion cannot
+// make valid.
+_TaskName: {
+	IN:  string
+	out: strings.ToLower(strings.Replace(strings.Replace(strings.Replace(IN, "/", "-", -1), ".", "-", -1), "_", "-", -1))
+}
+
+// Kustomize and Kubernetes are identical.
+
+// https://holos.run/docs/api/author/v1beta1/#Kustomize
+#Kustomize: #Kubernetes
+
+// https://holos.run/docs/api/author/v1beta1/#Kubernetes
+#Kubernetes: {
+	Name:            _
+	Resources:       _
+	KustomizeConfig: _
+
+	TaskSet: spec: tasks: {
+		let ResourcesOutput = "resources.gen.yaml"
+		resources: {
+			kind:        "Resources"
+			output:      ResourcesOutput
+			"resources": Resources
+		}
+		for x in KustomizeConfig.Files {
+			((_TaskName & {IN: "file-\(x.Source)"}).out): {
+				kind:   "File"
+				output: x.Source
+				file: source: x.Source
+			}
+		}
+		kustomize: {
+			kind: "Kustomize"
+			inputs: [
+				ResourcesOutput,
+				for x in KustomizeConfig.Files {x.Source},
+			]
+			output: "\(Name).gen.yaml"
+			"kustomize": kustomization: KustomizeConfig.Kustomization & {
+				"resources": [
+					ResourcesOutput,
+					for x in KustomizeConfig.Files {x.Source},
+					for x in KustomizeConfig.Resources {x.Source},
+				]
+			}
+		}
+	}
+}
+
+// https://holos.run/docs/api/author/v1beta1/#Helm
+#Helm: {
+	Name:            _
+	Resources:       _
+	KustomizeConfig: _
+
+	Chart: {
+		name:    string | *Name
+		release: string | *name
+	}
+	Values:       _
+	ValueFiles?:  _
+	EnableHooks:  _
+	Namespace?:   _
+	APIVersions?: _
+	KubeVersion?: _
+
+	TaskSet: spec: tasks: {
+		let HelmOutput = "helm.gen.yaml"
+		let ResourcesOutput = "resources.gen.yaml"
+		helm: {
+			kind:   "Helm"
+			output: HelmOutput
+			"helm": core.#Helm & {
+				chart:  Chart
+				values: Values
+				if ValueFiles != _|_ {
+					valueFiles: ValueFiles
+				}
+				enableHooks: EnableHooks
+				if Namespace != _|_ {
+					namespace: Namespace
+				}
+				if APIVersions != _|_ {
+					apiVersions: APIVersions
+				}
+				if KubeVersion != _|_ {
+					kubeVersion: KubeVersion
+				}
+			}
+		}
+		resources: {
+			kind:        "Resources"
+			output:      ResourcesOutput
+			"resources": Resources
+		}
+		for x in KustomizeConfig.Files {
+			((_TaskName & {IN: "file-\(x.Source)"}).out): {
+				kind:   "File"
+				output: x.Source
+				file: source: x.Source
+			}
+		}
+		kustomize: {
+			kind: "Kustomize"
+			inputs: [
+				HelmOutput,
+				ResourcesOutput,
+				for x in KustomizeConfig.Files {x.Source},
+			]
+			output: "\(Name).gen.yaml"
+			"kustomize": kustomization: KustomizeConfig.Kustomization & {
+				"resources": [
+					HelmOutput,
+					ResourcesOutput,
+					for x in KustomizeConfig.Files {x.Source},
+					for x in KustomizeConfig.Resources {x.Source},
+				]
+			}
+		}
+	}
+}
+
+#ComponentConfig: {
+	Name:          _
+	Labels:        _
+	Annotations:   _
+	OutputBaseDir: _
+	Tasks:         _
+
+	_outputPath: string
+	if OutputBaseDir == "" {
+		_outputPath: "components/\(Name)"
+	}
+	if OutputBaseDir != "" {
+		_outputPath: "\(OutputBaseDir)/components/\(Name)"
+	}
+
+	// TaskSet represents the derived TaskSet produced for the holos render
+	// component command.  Tasks mix in by unification; the deploy sink writes
+	// the final artifact per doc/design/v1beta1/schema.md#d2-artifact-writing.
+	TaskSet: core.#TaskSet & {
+		metadata: "name": Name
+		if len(Labels) != 0 {
+			metadata: labels: Labels
+		}
+		if len(Annotations) != 0 {
+			metadata: annotations: Annotations
+		}
+		spec: "tasks": Tasks
+		spec: "tasks": deploy: {
+			kind: "Artifact"
+			inputs: ["\(Name).gen.yaml"]
+			artifact: path: "\(_outputPath)/\(Name).gen.yaml"
+		}
+	}
+}

--- a/internal/generate/platforms/cue.mod/pkg/github.com/holos-run/holos/api/author/v1beta1/definitions.cue
+++ b/internal/generate/platforms/cue.mod/pkg/github.com/holos-run/holos/api/author/v1beta1/definitions.cue
@@ -37,19 +37,27 @@ import (
 	}
 }
 
-// _TaskName converts a component directory file path into a valid task name.
-// Task names must be RFC 1123 labels per
-// doc/design/v1beta1/schema.md#d3-task-naming-and-namespacing.  The out field
-// is defined only when the converted name matches the RFC 1123 pattern, so a
-// source path this conversion cannot make valid fails evaluation immediately
-// (undefined field: out) instead of producing an invalid task name.  Use the
-// ComponentConfig Tasks field directly for such sources.
-_TaskName: {
-	IN:   string
-	_out: strings.ToLower(strings.Replace(strings.Replace(strings.Replace(IN, "/", "-", -1), ".", "-", -1), "_", "-", -1))
-	if _out =~ "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$" {
-		out: _out
+// _TaskKey validates a task name is an RFC 1123 label per
+// doc/design/v1beta1/schema.md#d3-task-naming-and-namespacing: lowercase
+// alphanumerics and interior hyphens, at most 63 characters.  The out field
+// is defined only when IN is valid, so an invalid task name fails evaluation
+// immediately (undefined field: out) instead of exporting.
+_TaskKey: {
+	IN: string
+	if IN =~ "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$" && len(IN) <= 63 {
+		out: IN
 	}
+}
+
+// _TaskName converts a component directory file path into a valid task name
+// validated by _TaskKey.  A source path this conversion cannot make valid
+// fails evaluation immediately.  Use the ComponentConfig Tasks field directly
+// for such sources.
+_TaskName: {
+	IN: string
+	out: (_TaskKey & {
+		"IN": strings.ToLower(strings.Replace(strings.Replace(strings.Replace(IN, "/", "-", -1), ".", "-", -1), "_", "-", -1))
+	}).out
 }
 
 // Kustomize and Kubernetes are identical.
@@ -194,7 +202,13 @@ _TaskName: {
 		if len(Annotations) != 0 {
 			metadata: annotations: Annotations
 		}
-		spec: "tasks": Tasks
+
+		// Mix in Tasks, validating each task name per schema.md D3.
+		spec: "tasks": {
+			for k, v in Tasks {
+				((_TaskKey & {IN: k}).out): v
+			}
+		}
 		spec: "tasks": deploy: {
 			kind: "Artifact"
 			inputs: ["\(Name).gen.yaml"]

--- a/internal/generate/platforms/v1beta1/.gitignore
+++ b/internal/generate/platforms/v1beta1/.gitignore
@@ -1,0 +1,10 @@
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+vendor/
+node_modules/
+tmp/

--- a/internal/generate/platforms/v1beta1/platform/platform.gen.cue
+++ b/internal/generate/platforms/v1beta1/platform/platform.gen.cue
@@ -1,0 +1,10 @@
+package holos
+
+import "github.com/holos-run/holos/api/author/v1beta1:author"
+
+// holos represents the field holos render platform evaluates, the resource
+// field of the author.#Platform definition constructed from a components
+// struct.
+holos: platform.resource
+
+platform: author.#Platform

--- a/internal/generate/platforms/v1beta1/platform/typemeta.cue
+++ b/internal/generate/platforms/v1beta1/platform/typemeta.cue
@@ -1,0 +1,6 @@
+@extern(embed)
+package holos
+
+import "github.com/holos-run/holos/api/core/v1beta1:core"
+
+holos: core.#Platform @embed(file=typemeta.yaml)

--- a/internal/generate/platforms/v1beta1/platform/typemeta.yaml
+++ b/internal/generate/platforms/v1beta1/platform/typemeta.yaml
@@ -1,0 +1,2 @@
+kind: Platform
+apiVersion: v1beta1

--- a/internal/generate/platforms/v1beta1/resources.cue
+++ b/internal/generate/platforms/v1beta1/resources.cue
@@ -1,0 +1,49 @@
+package holos
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	batchv1 "k8s.io/api/batch/v1"
+
+	ci "cert-manager.io/clusterissuer/v1"
+	rgv1 "gateway.networking.k8s.io/referencegrant/v1beta1"
+	certv1 "cert-manager.io/certificate/v1"
+	hrv1 "gateway.networking.k8s.io/httproute/v1"
+	gwv1 "gateway.networking.k8s.io/gateway/v1"
+	ap "argoproj.io/appproject/v1alpha1"
+	es "external-secrets.io/externalsecret/v1beta1"
+	ss "external-secrets.io/secretstore/v1beta1"
+)
+
+#Resources: {
+	[Kind=string]: [InternalLabel=string]: {
+		kind: Kind
+		metadata: name: string | *InternalLabel
+	}
+
+	AppProject?: [_]:         ap.#AppProject
+	Certificate?: [_]:        certv1.#Certificate
+	ClusterIssuer?: [_]:      ci.#ClusterIssuer
+	ClusterRole?: [_]:        rbacv1.#ClusterRole
+	ClusterRoleBinding?: [_]: rbacv1.#ClusterRoleBinding
+	ConfigMap?: [_]:          corev1.#ConfigMap
+	CronJob?: [_]:            batchv1.#CronJob
+	Deployment?: [_]:         appsv1.#Deployment
+	ExternalSecret?: [_]:     es.#ExternalSecret
+	HTTPRoute?: [_]:          hrv1.#HTTPRoute
+	Job?: [_]:                batchv1.#Job
+	Namespace?: [_]:          corev1.#Namespace
+	ReferenceGrant?: [_]:     rgv1.#ReferenceGrant
+	Role?: [_]:               rbacv1.#Role
+	RoleBinding?: [_]:        rbacv1.#RoleBinding
+	Secret?: [_]:             corev1.#Secret
+	SecretStore?: [_]:        ss.#SecretStore
+	Service?: [_]:            corev1.#Service
+	ServiceAccount?: [_]:     corev1.#ServiceAccount
+	StatefulSet?: [_]:        appsv1.#StatefulSet
+
+	Gateway?: [_]: gwv1.#Gateway & {
+		spec: gatewayClassName: string | *"istio"
+	}
+}

--- a/internal/generate/platforms/v1beta1/schema.cue
+++ b/internal/generate/platforms/v1beta1/schema.cue
@@ -1,0 +1,37 @@
+package holos
+
+import "github.com/holos-run/holos/api/author/v1beta1:author"
+
+#ComponentConfig: author.#ComponentConfig & {
+	Name:      _Tags.component.name
+	Path:      _Tags.component.path
+	Resources: #Resources
+
+	// labels is an optional field, guard references to it.
+	if _Tags.component.labels != _|_ {
+		Labels: _Tags.component.labels
+	}
+
+	// annotations is an optional field, guard references to it.
+	if _Tags.component.annotations != _|_ {
+		Annotations: _Tags.component.annotations
+	}
+}
+
+// https://holos.run/docs/api/author/v1beta1/#Kubernetes
+#Kubernetes: close({
+	#ComponentConfig
+	author.#Kubernetes
+})
+
+// https://holos.run/docs/api/author/v1beta1/#Kustomize
+#Kustomize: close({
+	#ComponentConfig
+	author.#Kustomize
+})
+
+// https://holos.run/docs/api/author/v1beta1/#Helm
+#Helm: close({
+	#ComponentConfig
+	author.#Helm
+})

--- a/internal/generate/platforms/v1beta1/tags.cue
+++ b/internal/generate/platforms/v1beta1/tags.cue
@@ -1,0 +1,34 @@
+package holos
+
+import (
+	"encoding/json"
+
+	"github.com/holos-run/holos/api/core/v1beta1:core"
+)
+
+// Note: tags should have a reasonable default value for cue export.
+_Tags: {
+	// Standardized parameters
+	component: core.#Component & {
+		name: string | *"no-name" @tag(holos_component_name, type=string)
+		path: string | *"no-path" @tag(holos_component_path, type=string)
+
+		_labels_json: string | *"" @tag(holos_component_labels, type=string)
+		_labels: {}
+		if _labels_json != "" {
+			_labels: json.Unmarshal(_labels_json)
+		}
+		for k, v in _labels {
+			labels: (k): v
+		}
+
+		_annotations_json: string | *"" @tag(holos_component_annotations, type=string)
+		_annotations: {}
+		if _annotations_json != "" {
+			_annotations: json.Unmarshal(_annotations_json)
+		}
+		for k, v in _annotations {
+			annotations: (k): v
+		}
+	}
+}

--- a/internal/generate/platforms/v1beta1_template_test.go
+++ b/internal/generate/platforms/v1beta1_template_test.go
@@ -1,0 +1,117 @@
+package platforms
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"cuelang.org/go/cue"
+	core "github.com/holos-run/holos/api/core/v1beta1"
+	holoscue "github.com/holos-run/holos/internal/cue"
+	"github.com/holos-run/holos/internal/generate"
+)
+
+// TestV1Beta1PlatformRegistered verifies directory-based registration: adding
+// internal/generate/platforms/v1beta1 registers the platform with holos init
+// platform with no Go code change.
+func TestV1Beta1PlatformRegistered(t *testing.T) {
+	if !slices.Contains(generate.Platforms(), "v1beta1") {
+		t.Fatalf("want v1beta1 in generate.Platforms(), got %v", generate.Platforms())
+	}
+}
+
+// TestV1Beta1InitPlatformTemplate generates the v1beta1 platform into a temp
+// directory, adds a component written per the documented idiom (Component:
+// #Kubernetes & {...}; holos: Component.TaskSet), and verifies the component
+// exports a valid concrete core.#TaskSet assembled by the author layer.
+func TestV1Beta1InitPlatformTemplate(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	root := t.TempDir()
+	if err := generate.GeneratePlatform(ctx, root, "v1beta1"); err != nil {
+		t.Fatalf("could not generate platform: %v", err)
+	}
+
+	leaf := filepath.Join("components", "example")
+	dir := filepath.Join(root, leaf)
+	if err := os.MkdirAll(dir, 0o777); err != nil {
+		t.Fatal(err)
+	}
+
+	typemetaCue := `@extern(embed)
+package holos
+
+import "encoding/json"
+
+holos: _ @embed(file=typemeta.yaml)
+
+holos: {
+	_buildContext: string | *"{}" @tag(holos_build_context, type=string)
+	buildContext: json.Unmarshal(_buildContext)
+}
+`
+	typemetaYaml := "apiVersion: v1beta1\nkind: TaskSet\n"
+	componentCue := `package holos
+
+holos: Component.TaskSet
+
+Component: #Kubernetes & {
+	Resources: Namespace: example: metadata: name: "example"
+}
+`
+	files := map[string]string{
+		"typemeta.cue":  typemetaCue,
+		"typemeta.yaml": typemetaYaml,
+		"example.cue":   componentCue,
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o666); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tags := []string{
+		"holos_component_name=example",
+		"holos_component_path=" + leaf,
+	}
+	inst, err := holoscue.BuildInstance(root, leaf, tags)
+	if err != nil {
+		t.Fatalf("could not build instance: %v", err)
+	}
+	v, err := inst.HolosValue()
+	if err != nil {
+		t.Fatalf("could not get holos value: %v", err)
+	}
+	if err := v.Validate(cue.Concrete(true)); err != nil {
+		t.Fatalf("holos value is not a valid concrete TaskSet: %v", err)
+	}
+
+	var ts core.TaskSet
+	if err := v.Decode(&ts); err != nil {
+		t.Fatalf("could not decode TaskSet: %v", err)
+	}
+	if ts.APIVersion != "v1beta1" {
+		t.Errorf("want apiVersion v1beta1, got %s", ts.APIVersion)
+	}
+	if ts.Kind != "TaskSet" {
+		t.Errorf("want kind TaskSet, got %s", ts.Kind)
+	}
+	if ts.Metadata.Name != "example" {
+		t.Errorf("want metadata.name example, got %s", ts.Metadata.Name)
+	}
+
+	for _, name := range []string{"resources", "kustomize", "deploy"} {
+		if _, ok := ts.Spec.Tasks[name]; !ok {
+			t.Errorf("want task %s in spec.tasks, got %v", name, ts.Spec.Tasks)
+		}
+	}
+	if got, want := ts.Spec.Tasks["deploy"].Artifact.Path, core.FileOrDirectoryPath("components/example/example.gen.yaml"); got != want {
+		t.Errorf("want deploy artifact path %s, got %s", want, got)
+	}
+	if got, want := ts.Spec.Tasks["kustomize"].Output, core.FileOrDirectoryPath("example.gen.yaml"); got != want {
+		t.Errorf("want kustomize output %s, got %s", want, got)
+	}
+}

--- a/internal/generate/platforms/v1beta1_template_test.go
+++ b/internal/generate/platforms/v1beta1_template_test.go
@@ -114,4 +114,76 @@ Component: #Kubernetes & {
 	if got, want := ts.Spec.Tasks["kustomize"].Output, core.FileOrDirectoryPath("example.gen.yaml"); got != want {
 		t.Errorf("want kustomize output %s, got %s", want, got)
 	}
+
+	// KustomizeConfig.Files produces File tasks named by sanitizing the source
+	// path into an RFC 1123 label.
+	t.Run("FileTaskName", func(t *testing.T) {
+		filesCue := componentCue + `
+Component: KustomizeConfig: Files: "deployment.yaml": _
+`
+		ts := buildTaskSet(t, root, leaf, filesCue)
+		task, ok := ts.Spec.Tasks["file-deployment-yaml"]
+		if !ok {
+			t.Fatalf("want task file-deployment-yaml in spec.tasks, got %v", ts.Spec.Tasks)
+		}
+		if got, want := task.File.Source, core.FilePath("deployment.yaml"); got != want {
+			t.Errorf("want file source %s, got %s", want, got)
+		}
+	})
+
+	// A file source the sanitizer cannot convert to an RFC 1123 label fails
+	// evaluation instead of producing an invalid task name.
+	t.Run("InvalidFileTaskName", func(t *testing.T) {
+		badCue := componentCue + `
+Component: KustomizeConfig: Files: "patch+prod.yaml": _
+`
+		if err := os.WriteFile(filepath.Join(root, leaf, "example.cue"), []byte(badCue), 0o666); err != nil {
+			t.Fatal(err)
+		}
+		tags := []string{
+			"holos_component_name=example",
+			"holos_component_path=" + leaf,
+		}
+		inst, err := holoscue.BuildInstance(root, leaf, tags)
+		if err != nil {
+			return // load error also satisfies the guard
+		}
+		v, err := inst.HolosValue()
+		if err != nil {
+			return
+		}
+		if err := v.Validate(cue.Concrete(true)); err == nil {
+			t.Fatal("want evaluation error for invalid file task name, got nil")
+		}
+	})
+}
+
+// buildTaskSet writes componentCue as the example component definition,
+// builds the CUE instance, validates the holos value is concrete, and decodes
+// it into a core.TaskSet.
+func buildTaskSet(t *testing.T, root, leaf, componentCue string) core.TaskSet {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(root, leaf, "example.cue"), []byte(componentCue), 0o666); err != nil {
+		t.Fatal(err)
+	}
+	tags := []string{
+		"holos_component_name=example",
+		"holos_component_path=" + leaf,
+	}
+	inst, err := holoscue.BuildInstance(root, leaf, tags)
+	if err != nil {
+		t.Fatalf("could not build instance: %v", err)
+	}
+	v, err := inst.HolosValue()
+	if err != nil {
+		t.Fatalf("could not get holos value: %v", err)
+	}
+	if err := v.Validate(cue.Concrete(true)); err != nil {
+		t.Fatalf("holos value is not a valid concrete TaskSet: %v", err)
+	}
+	var ts core.TaskSet
+	if err := v.Decode(&ts); err != nil {
+		t.Fatalf("could not decode TaskSet: %v", err)
+	}
+	return ts
 }

--- a/internal/generate/platforms/v1beta1_template_test.go
+++ b/internal/generate/platforms/v1beta1_template_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"cuelang.org/go/cue"
@@ -134,28 +135,69 @@ Component: KustomizeConfig: Files: "deployment.yaml": _
 	// A file source the sanitizer cannot convert to an RFC 1123 label fails
 	// evaluation instead of producing an invalid task name.
 	t.Run("InvalidFileTaskName", func(t *testing.T) {
-		badCue := componentCue + `
+		requireTaskSetError(t, root, leaf, componentCue+`
 Component: KustomizeConfig: Files: "patch+prod.yaml": _
-`
-		if err := os.WriteFile(filepath.Join(root, leaf, "example.cue"), []byte(badCue), 0o666); err != nil {
-			t.Fatal(err)
-		}
-		tags := []string{
-			"holos_component_name=example",
-			"holos_component_path=" + leaf,
-		}
-		inst, err := holoscue.BuildInstance(root, leaf, tags)
-		if err != nil {
-			return // load error also satisfies the guard
-		}
-		v, err := inst.HolosValue()
-		if err != nil {
-			return
-		}
-		if err := v.Validate(cue.Concrete(true)); err == nil {
-			t.Fatal("want evaluation error for invalid file task name, got nil")
+`)
+	})
+
+	// A file source producing a task name over the 63 character RFC 1123
+	// label length limit fails evaluation.
+	t.Run("LongFileTaskName", func(t *testing.T) {
+		requireTaskSetError(t, root, leaf, componentCue+`
+Component: KustomizeConfig: Files: "`+strings.Repeat("a", 64)+`.yaml": _
+`)
+	})
+
+	// A custom task mixed in through the Tasks field must use a valid RFC
+	// 1123 label task name per schema.md D3.
+	t.Run("InvalidCustomTaskName", func(t *testing.T) {
+		requireTaskSetError(t, root, leaf, componentCue+`
+Component: Tasks: "bad_key": {
+	kind: "Resources"
+	resources: {}
+	output: "bad.gen.yaml"
+}
+`)
+	})
+
+	// A valid custom task name passes through unchanged.
+	t.Run("ValidCustomTaskName", func(t *testing.T) {
+		ts := buildTaskSet(t, root, leaf, componentCue+`
+Component: Tasks: gitops: {
+	kind: "Resources"
+	resources: {}
+	output: "gitops.gen.yaml"
+}
+`)
+		if _, ok := ts.Spec.Tasks["gitops"]; !ok {
+			t.Fatalf("want task gitops in spec.tasks, got %v", ts.Spec.Tasks)
 		}
 	})
+}
+
+// requireTaskSetError writes componentCue as the example component definition
+// and requires CUE evaluation to fail at load, holos value, or concrete
+// validation.
+func requireTaskSetError(t *testing.T, root, leaf, componentCue string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(root, leaf, "example.cue"), []byte(componentCue), 0o666); err != nil {
+		t.Fatal(err)
+	}
+	tags := []string{
+		"holos_component_name=example",
+		"holos_component_path=" + leaf,
+	}
+	inst, err := holoscue.BuildInstance(root, leaf, tags)
+	if err != nil {
+		return // load error satisfies the guard
+	}
+	v, err := inst.HolosValue()
+	if err != nil {
+		return
+	}
+	if err := v.Validate(cue.Concrete(true)); err == nil {
+		t.Fatal("want evaluation error, got nil")
+	}
 }
 
 // buildTaskSet writes componentCue as the example component definition,


### PR DESCRIPTION
## Summary
- Add `internal/component/platform/components/v1beta1/typemeta.{cue,yaml}` mirroring the v1alpha6 fixture, using `@embed(file=typemeta.yaml)` with `apiVersion: v1beta1, kind: TaskSet`.
- Add `internal/generate/platforms/v1beta1/` (`schema.cue`, `tags.cue`, `resources.cue`, `platform/`). Registration is directory-based: `generate.Platforms()` lists `v1beta1` with no Go code change (verified by `TestV1Beta1PlatformRegistered`).
- Add the hand-written author-layer assembly CUE at `internal/generate/platforms/cue.mod/pkg/github.com/holos-run/holos/api/author/v1beta1/definitions.cue`, mirroring the v1alpha6 sibling. It derives `TaskSet.spec.tasks` from the author wrapper fields: `#Helm` produces a `helm` task, `#Kubernetes`/`#Kustomize` produce a `resources` task plus `File` tasks for `KustomizeConfig.Files`, all feeding a `kustomize` transform task whose output flows to the `deploy` `Artifact` sink per schema.md D2. `ComponentConfig.Tasks` entries unify directly into `spec.tasks`.
- File task names are sanitized to RFC 1123 labels (schema.md D3) since task names are struct keys: `deployment.yaml` becomes `file-deployment-yaml`.
- Add `TestV1Beta1InitPlatformTemplate`: generates the v1beta1 platform into a temp dir, writes a component using the documented idiom (`Component: #Kubernetes & {...}; holos: Component.TaskSet`), and asserts the exported value is a valid concrete `core.#TaskSet` with the expected `resources`/`kustomize`/`deploy` tasks and artifact path.

## Platform typemeta decision
The platform typemeta is `kind: Platform, apiVersion: v1beta1`. `api/core/v1beta1/types.go` defines its own `Platform` (apiVersion defaulting to `v1beta1`), and `doc/design/v1beta1/README.md` ("The Go tooling knows only Platform → Component") states v1beta1 adds one case to the `internal/platform/platform.go` dispatch. That Go dispatch case belongs to the component dispatch task; today the default (v1alpha5) loader decodes the v1beta1 platform resource correctly, so `holos show platform` works as verified below.

## Test plan
- [x] `make lint && make test` pass.
- [x] `holos init platform v1beta1` succeeds in an empty directory; `holos show platform` prints the v1beta1 platform; `cue vet ./...` passes.
- [x] Registered `#Kubernetes` and `#Helm` components in the generated platform: `cue vet ./...` passes, `holos show platform` lists both, and `cue export -e holos` produces the expected TaskSet (helm/resources/file → kustomize → deploy) for each.

Fixes HOL-1511