### PR TITLE
component: dispatch v1beta1 across render, platform, show, and compile

### DIFF
--- a/internal/cli/show.go
+++ b/internal/cli/show.go
@@ -10,6 +10,7 @@ import (
 
 	v1alpha5 "github.com/holos-run/holos/api/core/v1alpha5"
 	v1alpha6 "github.com/holos-run/holos/api/core/v1alpha6"
+	v1beta1 "github.com/holos-run/holos/api/core/v1beta1"
 	"github.com/holos-run/holos/internal/cli/command"
 	"github.com/holos-run/holos/internal/compile"
 	"github.com/holos-run/holos/internal/errors"
@@ -116,8 +117,13 @@ func (s *showBuildPlans) Run(ctx context.Context, p *platform.Platform) error {
 		if err := json.Unmarshal(buildPlanResponse.RawMessage, &tm); err != nil {
 			return errors.Format("could not discriminate type meta: %w", err)
 		}
-		if tm.Kind != "BuildPlan" {
-			return errors.Format("invalid kind %s: must be BuildPlan", tm.Kind)
+		// v1beta1 replaces the BuildPlan kind with TaskSet.
+		wantKind := "BuildPlan"
+		if tm.APIVersion == "v1beta1" {
+			wantKind = "TaskSet"
+		}
+		if tm.Kind != wantKind {
+			return errors.Format("invalid kind %s: must be %s", tm.Kind, wantKind)
 		}
 
 		var buildPlan any
@@ -126,6 +132,8 @@ func (s *showBuildPlans) Run(ctx context.Context, p *platform.Platform) error {
 			buildPlan = &v1alpha5.BuildPlan{}
 		case "v1alpha6":
 			buildPlan = &v1alpha6.BuildPlan{}
+		case "v1beta1":
+			buildPlan = &v1beta1.TaskSet{}
 		default:
 			slog.WarnContext(ctx, fmt.Sprintf("unknown BuildPlan APIVersion %s: assuming v1alpha6 schema", tm.APIVersion))
 			buildPlan = &v1alpha6.BuildPlan{}

--- a/internal/compile/compile_test.go
+++ b/internal/compile/compile_test.go
@@ -1,0 +1,103 @@
+package compile
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/holos-run/holos/internal/holos"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// typemetaCUE mirrors the embedded v1beta1 typemeta scaffolding from
+// internal/component/platform/components/v1beta1/typemeta.cue.
+const typemetaCUE = `@extern(embed)
+package holos
+
+import "encoding/json"
+
+holos: _ @embed(file=typemeta.yaml)
+
+holos: {
+	_buildContext: string | *"{}" @tag(holos_build_context, type=string)
+	buildContext: json.Unmarshal(_buildContext)
+}
+`
+
+// componentCUE represents a minimal v1beta1 TaskSet component.
+const componentCUE = `package holos
+
+holos: {
+	metadata: name: "example"
+	spec: tasks: {
+		resources: {
+			kind:   "Resources"
+			output: "example.gen.yaml"
+			resources: ConfigMap: example: {
+				apiVersion: "v1"
+				kind:       "ConfigMap"
+				metadata: name: "example"
+			}
+		}
+		deploy: {
+			kind: "Artifact"
+			inputs: ["example.gen.yaml"]
+		}
+	}
+}
+`
+
+// TestCompilerBeta1Envelope is a regression test proving a v1beta1 component
+// compiles through the existing v1alpha6 BuildPlanRequest envelope.  The
+// envelope discriminates the request version while the component's own version
+// is re-discriminated from typemeta.yaml inside the read loop.
+func TestCompilerBeta1Envelope(t *testing.T) {
+	root := t.TempDir()
+	files := map[string]string{
+		"cue.mod/module.cue":               "module: \"holos.example\"\nlanguage: {\n\tversion: \"v0.12.0\"\n}\n",
+		"components/example/typemeta.yaml": "apiVersion: v1beta1\nkind: TaskSet\n",
+		"components/example/typemeta.cue":  typemetaCUE,
+		"components/example/component.cue": componentCUE,
+	}
+	for path, content := range files {
+		full := filepath.Join(root, path)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o777))
+		require.NoError(t, os.WriteFile(full, []byte(content), 0o666))
+	}
+
+	req := BuildPlanRequest{
+		APIVersion: "v1alpha6",
+		Kind:       holos.BuildPlanRequest,
+		Root:       root,
+		Leaf:       "components/example",
+		WriteTo:    holos.WriteToDefault,
+		TempDir:    "${TMPDIR_PLACEHOLDER}",
+	}
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	var out bytes.Buffer
+	c := New()
+	c.R = bytes.NewReader(data)
+	c.W = &out
+
+	require.NoError(t, c.Run(t.Context()))
+
+	var tm holos.TypeMeta
+	require.NoError(t, json.Unmarshal(out.Bytes(), &tm))
+	assert.Equal(t, "v1beta1", tm.APIVersion)
+	assert.Equal(t, "TaskSet", tm.Kind)
+
+	// The exported TaskSet must round trip the tasks.
+	var taskSet struct {
+		Spec struct {
+			Tasks map[string]any `json:"tasks"`
+		} `json:"spec"`
+	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &taskSet))
+	assert.Contains(t, taskSet.Spec.Tasks, "resources")
+	assert.Contains(t, taskSet.Spec.Tasks, "deploy")
+}

--- a/internal/component/component.go
+++ b/internal/component/component.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/holos-run/holos/internal/component/v1alpha5"
 	"github.com/holos-run/holos/internal/component/v1alpha6"
+	"github.com/holos-run/holos/internal/component/v1beta1"
 	"github.com/holos-run/holos/internal/errors"
 	"github.com/holos-run/holos/internal/holos"
 	"github.com/holos-run/holos/internal/logger"
@@ -70,7 +71,7 @@ func (c *Component) Render(ctx context.Context, writeTo string, stderr io.Writer
 	}
 
 	switch tm.APIVersion {
-	case "v1alpha6":
+	case "v1alpha6", "v1beta1":
 		if err := c.render(ctx, tm, writeTo, stderr, concurrency, tagMap); err != nil {
 			return errors.Format("could not render component: %w", err)
 		}
@@ -92,6 +93,22 @@ func (c *Component) BuildPlan(tm holos.TypeMeta, opts holos.BuildOpts, tagMap ho
 	tags := tagMap.Tags()
 	// discriminate the version.
 	switch tm.APIVersion {
+	case "v1beta1":
+		// Prepare runtime build context for injection as a cue tag.
+		bc, err := v1beta1.NewBuildContext(opts)
+		if err != nil {
+			return bp, errors.Format("invalid build context: %w", err)
+		}
+		buildContextTags, err := bc.Tags()
+		if err != nil {
+			return bp, errors.Format("could not get build context tag: %w", err)
+		}
+		// Append the standard tags for the component name, labels, annotations.
+		tags = append(tags, opts.Tags...)
+		// Append build context tags such as the holos managed temp directory.
+		tags = append(tags, buildContextTags...)
+		// the version specific task set itself embedded into the wrapper.
+		bp = BuildPlan{BuildPlan: &v1beta1.TaskSet{Opts: opts}}
 	case "v1alpha6":
 		// Prepare runtime build context for injection as a cue tag.
 		bc, err := v1alpha6.NewBuildContext(opts)
@@ -141,8 +158,13 @@ func (c *Component) BuildPlan(tm holos.TypeMeta, opts holos.BuildOpts, tagMap ho
 // building the CUE instance.  Useful to determine which build tags need to be
 // injected depending on the apiVersion of the component.
 func (c *Component) render(ctx context.Context, tm holos.TypeMeta, writeTo string, stderr io.Writer, concurrency int, tagMap holos.TagMap) error {
-	if tm.Kind != "BuildPlan" {
-		return errors.Format("unsupported kind: %s, want BuildPlan", tm.Kind)
+	// v1beta1 replaces the BuildPlan kind with TaskSet.
+	wantKind := "BuildPlan"
+	if tm.APIVersion == "v1beta1" {
+		wantKind = "TaskSet"
+	}
+	if tm.Kind != wantKind {
+		return errors.Format("unsupported kind: %s, want %s", tm.Kind, wantKind)
 	}
 	// temp directory is an important part of the build context.
 	tempDir, err := os.MkdirTemp("", "holos.render")

--- a/internal/component/component_test.go
+++ b/internal/component/component_test.go
@@ -51,6 +51,44 @@ func TestComponentAlpha6(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestComponentBeta1(t *testing.T) {
+	h := newHarness(t, "components/v1beta1")
+	err := h.c.Render(h.ctx, holos.WriteToDefault, os.Stderr, 1, nil)
+	assert.NoError(t, err)
+
+	// Verify the artifact was written to the expected path
+	expectedPath := filepath.Join(h.c.Root, holos.WriteToDefault, "v1beta1/example/example.gen.yaml")
+	data, err := os.ReadFile(expectedPath)
+	assert.NoError(t, err, "Expected manifest file to exist at %s", expectedPath)
+	assert.Contains(t, string(data), "kind: ConfigMap")
+}
+
+// TestComponentTypeMetaDefault asserts a component without a typemeta.yaml
+// file defaults to a v1alpha5 BuildPlan.
+func TestComponentTypeMetaDefault(t *testing.T) {
+	h := newHarness(t, "components/v1alpha5")
+	tm, err := h.c.TypeMeta()
+	assert.NoError(t, err)
+	assert.Equal(t, "v1alpha5", tm.APIVersion)
+	assert.Equal(t, "BuildPlan", tm.Kind)
+}
+
+// TestComponentUnsupportedVersion asserts unsupported api versions produce an
+// error instead of silently falling through to another version.
+func TestComponentUnsupportedVersion(t *testing.T) {
+	h := newHarness(t, "components/unsupported")
+	dir := filepath.Join(h.c.Root, h.c.Path)
+	if err := os.MkdirAll(dir, 0o777); err != nil {
+		t.Fatalf("could not make component directory: %v", err)
+	}
+	data := []byte("apiVersion: v1alpha4\nkind: BuildPlan\n")
+	if err := os.WriteFile(filepath.Join(dir, "typemeta.yaml"), data, 0o666); err != nil {
+		t.Fatalf("could not write typemeta.yaml: %v", err)
+	}
+	err := h.c.Render(h.ctx, holos.WriteToDefault, os.Stderr, 1, nil)
+	assert.ErrorContains(t, err, "unsupported version: v1alpha4")
+}
+
 type harness struct {
 	c   *component.Component
 	ctx context.Context

--- a/internal/component/platform/components/v1beta1/component.cue
+++ b/internal/component/platform/components/v1beta1/component.cue
@@ -1,0 +1,22 @@
+package holos
+
+// A minimal v1beta1 TaskSet exercising the Resources -> Artifact data flow.
+holos: {
+	metadata: name: "example"
+	spec: tasks: {
+		resources: {
+			kind:   "Resources"
+			output: "example.gen.yaml"
+			resources: ConfigMap: example: {
+				apiVersion: "v1"
+				kind:       "ConfigMap"
+				metadata: name: "example"
+			}
+		}
+		deploy: {
+			kind: "Artifact"
+			inputs: ["example.gen.yaml"]
+			artifact: path: "v1beta1/example/example.gen.yaml"
+		}
+	}
+}

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -135,7 +135,10 @@ func (p *Platform) Load(ctx context.Context) error {
 	}
 
 	switch tm.APIVersion {
-	case "v1alpha6":
+	// The v1beta1 platform schema is structurally identical to v1alpha6, so
+	// v1beta1 platforms load with the v1alpha6 loader.  Dispatch is explicit
+	// to avoid a silent fall-through.  See doc/design/v1beta1/README.md.
+	case "v1alpha6", "v1beta1":
 		p.Platform = &v1alpha6.Platform{}
 	default:
 		p.Platform = &v1alpha5.Platform{}


### PR DESCRIPTION
## Summary
- `component.Render` and `component.BuildPlan` dispatch `v1beta1` to the TaskSet engine, mirroring the v1alpha6 arm with `v1beta1.NewBuildContext` tag injection; the generic render helper's kind guard now requires `TaskSet` for v1beta1 and `BuildPlan` otherwise.
- `platform.Load` dispatches `v1beta1` explicitly to the v1alpha6 loader — the v1beta1 platform schema is structurally identical (per the HOL-1511 platform-typemeta decision recorded in PR #474); no silent fall-through.
- `show buildplans` decodes v1beta1 responses into `*corev1beta1.TaskSet` and requires kind `TaskSet` for v1beta1, `BuildPlan` for alpha versions; unknown versions keep the existing warn-and-assume-v1alpha6 behavior.
- `compile`: no envelope change needed — the v1alpha6 `BuildPlanRequest` envelope re-discriminates the component's own version via `component.TypeMeta()` inside the read loop. Added a regression test proving a v1beta1 component compiles through the existing envelope end-to-end.
- Tests: embedded v1beta1 render fixture (Resources → Artifact), explicit typemeta-default-to-v1alpha5 assertion, and unsupported-version error assertion.

Fixes HOL-1512

## Manual verification

Mixed v1alpha6 + v1beta1 scratch platform (`holos init platform v1beta1` plus one raw v1alpha6 BuildPlan component `alpha` and one raw v1beta1 TaskSet component `beta`):

```console
$ holos render component components/beta
$ cat deploy/beta/beta.gen.yaml
apiVersion: v1
kind: ConfigMap
metadata:
    name: beta

$ holos render platform
rendered alpha in 78.863768ms
rendered beta in 81.586147ms
rendered platform in 81.633998ms

$ holos show buildplans   # abridged to top-level fields
apiVersion: v1alpha6
kind: BuildPlan
...
---
apiVersion: v1beta1
kind: TaskSet
...
```

## Test plan
- [x] `make lint && make test` pass locally.
- [x] `holos render component` renders a v1beta1 component (output above).
- [x] `holos render platform` renders a mixed v1alpha6 + v1beta1 platform (output above).
- [x] `holos show buildplans` emits a v1beta1 TaskSet and a v1alpha6 BuildPlan in the same platform (output above).
- [x] Component without `typemeta.yaml` defaults to v1alpha5 (explicit test added).
- [x] Unsupported versions produce `unsupported version: %s` errors (explicit test added).