### PR TITLE
test: v1beta1 fixtures, golden files, txtar suite, and mixed-version gate

### DIFF
--- a/cmd/holos/main_test.go
+++ b/cmd/holos/main_test.go
@@ -30,6 +30,10 @@ func TestIssues_v1alpha5(t *testing.T) {
 	testscript.Run(t, params(filepath.Join("v1alpha5", "issues")))
 }
 
+func TestSchemas_v1beta1(t *testing.T) {
+	testscript.Run(t, params(filepath.Join("v1beta1", "schemas")))
+}
+
 func TestCLI(t *testing.T) {
 	testscript.Run(t, params("cli"))
 }

--- a/cmd/holos/tests/v1beta1/schemas/init.txt
+++ b/cmd/holos/tests/v1beta1/schemas/init.txt
@@ -1,0 +1,19 @@
+# holos init platform v1beta1
+
+# Start in an empty directory.
+cd $WORK
+
+# Generate the directory structure we're going to work in.
+exec holos init platform v1beta1 --force
+
+# Platforms are empty by default.
+exec holos render platform
+stderr -count=1 '^rendered platform'
+
+# The platform resource uses the v1beta1 api version.
+exec holos show platform
+stdout 'kind: Platform'
+stdout 'apiVersion: v1beta1'
+
+# The generated module passes cue vet.
+exec holos cue vet ./...

--- a/cmd/holos/tests/v1beta1/schemas/mixed.txt
+++ b/cmd/holos/tests/v1beta1/schemas/mixed.txt
@@ -1,0 +1,122 @@
+# One platform renders v1alpha6 and v1beta1 components in one invocation.
+
+# Start in an empty directory.
+cd $WORK
+
+# Generate the directory structure we're going to work in.
+exec holos init platform v1beta1 --force
+
+# Render both components in one invocation.
+exec holos render platform
+stderr -count=1 '^rendered alpha'
+stderr -count=1 '^rendered beta'
+stderr -count=1 '^rendered platform'
+
+# Assert the rendered manifests.
+exec holos compare yaml deploy/components/alpha/alpha.gen.yaml want/alpha.gen.yaml
+exec holos compare yaml deploy/components/beta/beta.gen.yaml want/beta.gen.yaml
+
+# Show buildplans emits one v1alpha6 BuildPlan and one v1beta1 TaskSet.
+exec holos show buildplans
+stdout -count=1 'kind: BuildPlan'
+stdout -count=1 'apiVersion: v1alpha6'
+stdout -count=1 'kind: TaskSet'
+stdout -count=1 'apiVersion: v1beta1'
+
+-- platform/components.cue --
+package holos
+
+platform: components: {
+	alpha: {
+		name: "alpha"
+		path: "components/alpha"
+	}
+	beta: {
+		name: "beta"
+		path: "components/beta"
+	}
+}
+-- components/alpha/buildplan.cue --
+package holos
+
+import "github.com/holos-run/holos/api/core/v1alpha6:core"
+
+holos: core.#BuildPlan & {
+	metadata: name: "alpha"
+	spec: artifacts: [{
+		artifact: "components/alpha/alpha.gen.yaml"
+		generators: [{
+			kind:   "Resources"
+			output: artifact
+			resources: ConfigMap: alpha: {
+				apiVersion: "v1"
+				kind:       "ConfigMap"
+				metadata: name: "alpha"
+			}
+		}]
+	}]
+}
+-- components/alpha/typemeta.cue --
+@extern(embed)
+package holos
+
+import "encoding/json"
+
+holos: _ @embed(file=typemeta.yaml)
+
+holos: {
+	_buildContext: string | *"{}" @tag(holos_build_context, type=string)
+	buildContext: json.Unmarshal(_buildContext)
+}
+-- components/alpha/typemeta.yaml --
+apiVersion: v1alpha6
+kind: BuildPlan
+-- components/beta/taskset.cue --
+package holos
+
+import "github.com/holos-run/holos/api/core/v1beta1:core"
+
+holos: core.#TaskSet & {
+	metadata: name: "beta"
+	spec: tasks: {
+		resources: {
+			kind:   "Resources"
+			output: "beta.gen.yaml"
+			"resources": ConfigMap: beta: {
+				apiVersion: "v1"
+				kind:       "ConfigMap"
+				metadata: name: "beta"
+			}
+		}
+		deploy: {
+			kind: "Artifact"
+			inputs: ["beta.gen.yaml"]
+			artifact: path: "components/beta/beta.gen.yaml"
+		}
+	}
+}
+-- components/beta/typemeta.cue --
+@extern(embed)
+package holos
+
+import "encoding/json"
+
+holos: _ @embed(file=typemeta.yaml)
+
+holos: {
+	_buildContext: string | *"{}" @tag(holos_build_context, type=string)
+	buildContext: json.Unmarshal(_buildContext)
+}
+-- components/beta/typemeta.yaml --
+apiVersion: v1beta1
+kind: TaskSet
+-- want/alpha.gen.yaml --
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alpha
+-- want/beta.gen.yaml --
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: beta

--- a/cmd/holos/tests/v1beta1/schemas/render.txt
+++ b/cmd/holos/tests/v1beta1/schemas/render.txt
@@ -1,0 +1,57 @@
+# holos render platform with a v1beta1 author.#Kubernetes component
+
+# Start in an empty directory.
+cd $WORK
+
+# Generate the directory structure we're going to work in.
+exec holos init platform v1beta1 --force
+
+# Render the platform with the example component registered.
+exec holos render platform
+stderr -count=1 '^rendered example'
+stderr -count=1 '^rendered platform'
+
+# Assert the rendered manifest.
+exec holos compare yaml deploy/components/example/example.gen.yaml want/example.gen.yaml
+
+-- platform/example.cue --
+package holos
+
+platform: components: example: {
+	name: "example"
+	path: "components/example"
+}
+-- components/example/example.cue --
+package holos
+
+Component: #Kubernetes & {
+	Resources: ConfigMap: example: {
+		apiVersion: "v1"
+		kind:       "ConfigMap"
+		metadata: name: "example"
+		data: greeting: "hello"
+	}
+}
+holos: Component.TaskSet
+-- components/example/typemeta.cue --
+@extern(embed)
+package holos
+
+import "encoding/json"
+
+holos: _ @embed(file=typemeta.yaml)
+
+holos: {
+	_buildContext: string | *"{}" @tag(holos_build_context, type=string)
+	buildContext: json.Unmarshal(_buildContext)
+}
+-- components/example/typemeta.yaml --
+apiVersion: v1beta1
+kind: TaskSet
+-- want/example.gen.yaml --
+apiVersion: v1
+data:
+  greeting: hello
+kind: ConfigMap
+metadata:
+  name: example

--- a/internal/cli/show_test.go
+++ b/internal/cli/show_test.go
@@ -11,6 +11,7 @@ import (
 
 	v1alpha5 "github.com/holos-run/holos/api/core/v1alpha5"
 	v1alpha6 "github.com/holos-run/holos/api/core/v1alpha6"
+	v1beta1 "github.com/holos-run/holos/api/core/v1beta1"
 	"github.com/holos-run/holos/internal/cli"
 	"github.com/holos-run/holos/internal/generate"
 	"github.com/holos-run/holos/internal/platform"
@@ -115,6 +116,66 @@ func TestShowAlpha6(t *testing.T) {
 		})
 	})
 
+}
+
+// TestShowBeta1 asserts holos show buildplans emits a v1alpha6 BuildPlan and
+// a v1beta1 TaskSet for a mixed platform containing one component of each api
+// version.
+func TestShowBeta1(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// test cancellation
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	// Initialize the platform
+	if err := generate.GeneratePlatform(ctx, tempDir, "v1beta1"); err != nil {
+		t.Fatalf("could not generate platform: %v", err)
+	}
+
+	if err := fs.WalkDir(testutil.Fixtures, "fixtures/v1beta1", util.MakeCopyFunc(ctx, testutil.Fixtures, tempDir)); err != nil {
+		t.Fatalf("could not copy fixtures: %v", err)
+	}
+
+	t.Run("BuildPlans", func(t *testing.T) {
+		t.Run("MixedPlatform", func(t *testing.T) {
+			platformDir := filepath.Join(tempDir, "fixtures", "v1beta1", "platform1")
+			wantBytes, err := testutil.Fixtures.ReadFile("fixtures/v1beta1/platform1/expected_show_buildplans.yaml")
+			require.NoError(t, err)
+			holosExecutable, err := util.Executable()
+			require.NoError(t, err)
+
+			// The expected file contains two documents: a v1alpha6 BuildPlan
+			// followed by a v1beta1 TaskSet.
+			decoder := yaml.NewDecoder(bytes.NewReader(wantBytes))
+			var wantBuildPlan v1alpha6.BuildPlan
+			require.NoError(t, decoder.Decode(&wantBuildPlan))
+			wantBuildPlan.BuildContext.RootDir = tempDir
+			wantBuildPlan.BuildContext.HolosExecutable = holosExecutable
+			wantBuildPlan.BuildContext.LeafDir = "fixtures/v1beta1/components/alpha6/simple"
+			var wantTaskSet v1beta1.TaskSet
+			require.NoError(t, decoder.Decode(&wantTaskSet))
+			wantTaskSet.BuildContext.RootDir = tempDir
+			wantTaskSet.BuildContext.HolosExecutable = holosExecutable
+			wantTaskSet.BuildContext.LeafDir = "fixtures/v1beta1/components/task/command"
+
+			h := newHarness()
+			err = h.Run(ctx, "buildplans", platformDir)
+			require.NoError(t, err)
+
+			haveDecoder := yaml.NewDecoder(bytes.NewReader(h.stdout.Bytes()))
+			var haveBuildPlan v1alpha6.BuildPlan
+			require.NoError(t, haveDecoder.Decode(&haveBuildPlan))
+			var haveTaskSet v1beta1.TaskSet
+			require.NoError(t, haveDecoder.Decode(&haveTaskSet))
+
+			// Compare them in both directions.
+			require.Equal(t, wantBuildPlan, haveBuildPlan)
+			require.Equal(t, haveBuildPlan, wantBuildPlan)
+			require.Equal(t, wantTaskSet, haveTaskSet)
+			require.Equal(t, haveTaskSet, wantTaskSet)
+		})
+	})
 }
 
 func TestShowAlpha5(t *testing.T) {

--- a/internal/component/v1beta1/components_test.go
+++ b/internal/component/v1beta1/components_test.go
@@ -1,7 +1,11 @@
 package v1beta1_test
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
+	"io"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -9,6 +13,7 @@ import (
 	"github.com/holos-run/holos/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 const apiVersion string = "v1beta1"
@@ -60,10 +65,17 @@ func TestComponents(t *testing.T) {
 					assert.Equal(t, tm.APIVersion, apiVersion)
 
 					t.Run("Build", func(t *testing.T) {
-						bp, err := c.BuildPlan(tm, holos.NewBuildOpts(h.Root(), leaf, "deploy", t.TempDir()), holos.TagMap{})
+						opts := holos.NewBuildOpts(h.Root(), leaf, "deploy", t.TempDir())
+						// Capture stderr to assert on the policy rejection.
+						var stderr bytes.Buffer
+						opts.Stderr = &stderr
+						bp, err := c.BuildPlan(tm, opts, holos.TagMap{})
 						require.NoError(t, err, msg)
 						err = bp.Build(h.Ctx())
 						assert.ErrorContains(t, err, "could not run command", msg)
+						// The validator must fail because the policy forbids
+						// Secret resources, not for an unrelated reason.
+						assert.Contains(t, stderr.String(), "Forbidden: Use an ExternalSecret instead", msg)
 					})
 				})
 			})
@@ -90,15 +102,33 @@ func testComponent(t *testing.T, h *testutil.ComponentHarness, kind, name string
 			err = bp.Build(h.Ctx())
 			require.NoError(t, err, msg)
 
-			// Validate the rendered manifest
-			have, err := h.Load(filepath.Join("deploy", "components", kind, name, fmt.Sprintf("%s.gen.yaml", name)))
-			require.NoError(t, err, msg)
-			want, err := h.Load(filepath.Join(leaf, fmt.Sprintf("want_%s.gen.yaml", name)))
-			require.NoError(t, err, msg)
+			// Validate every document of the rendered manifest.
+			have := loadAll(t, h, filepath.Join("deploy", "components", kind, name, fmt.Sprintf("%s.gen.yaml", name)))
+			want := loadAll(t, h, filepath.Join(leaf, fmt.Sprintf("want_%s.gen.yaml", name)))
+			require.NotEmpty(t, want, msg)
 
 			// Validate in both directions
 			assert.Equal(t, want, have, msg)
 			assert.Equal(t, have, want, msg)
 		})
 	})
+}
+
+// loadAll unmarshals every document in the yaml stream at path relative to
+// the harness root.
+func loadAll(t *testing.T, h *testutil.ComponentHarness, path string) (docs []any) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(h.Root(), path))
+	require.NoError(t, err)
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	for {
+		var doc any
+		err := decoder.Decode(&doc)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+		docs = append(docs, doc)
+	}
+	return docs
 }

--- a/internal/component/v1beta1/components_test.go
+++ b/internal/component/v1beta1/components_test.go
@@ -1,0 +1,104 @@
+package v1beta1_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/holos-run/holos/internal/holos"
+	"github.com/holos-run/holos/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const apiVersion string = "v1beta1"
+
+func TestComponents(t *testing.T) {
+	tempDir := testutil.SetupPlatform(t, apiVersion)
+	h := testutil.NewComponentHarness(t, tempDir, apiVersion)
+	assert.NotEmpty(t, h.Root())
+
+	t.Run("WithNoTasks", func(t *testing.T) {
+		leaf := "components/minimal"
+		c := h.Component(leaf)
+		msg := fmt.Sprintf("Expected %s with no tasks to work, but do nothing", leaf)
+
+		tm, err := c.TypeMeta()
+		require.NoError(t, err, msg)
+
+		t.Run("TypeMeta", func(t *testing.T) {
+			assert.Equal(t, apiVersion, tm.APIVersion, msg)
+			assert.Equal(t, "TaskSet", tm.Kind, msg)
+		})
+
+		t.Run("Build", func(t *testing.T) {
+			bp, err := c.BuildPlan(tm, holos.NewBuildOpts(h.Root(), leaf, "deploy", t.TempDir()), holos.TagMap{})
+			require.NoError(t, err, msg)
+			err = bp.Build(h.Ctx())
+			require.NoError(t, err, msg)
+		})
+	})
+
+	t.Run("TaskSet", func(t *testing.T) {
+		t.Run("Task", func(t *testing.T) {
+			for _, tc := range []string{"command", "helm", "kustomize", "join", "dag"} {
+				testComponent(t, h, "task", tc)
+			}
+		})
+
+		t.Run("Validator", func(t *testing.T) {
+			t.Run("Command", func(t *testing.T) {
+				t.Run("SecretForbidden", func(t *testing.T) {
+					kind := "validator"
+					name := "secret"
+					path := filepath.Join("components", kind, name)
+					leaf := filepath.Join(h.Base(), path)
+					c := h.Component(path)
+					msg := fmt.Sprintf("Expected %s with %s to fail validation", path, kind)
+					tm, err := c.TypeMeta()
+					require.NoError(t, err, msg)
+					assert.Equal(t, tm.APIVersion, apiVersion)
+
+					t.Run("Build", func(t *testing.T) {
+						bp, err := c.BuildPlan(tm, holos.NewBuildOpts(h.Root(), leaf, "deploy", t.TempDir()), holos.TagMap{})
+						require.NoError(t, err, msg)
+						err = bp.Build(h.Ctx())
+						assert.ErrorContains(t, err, "could not run command", msg)
+					})
+				})
+			})
+		})
+	})
+}
+
+// testComponent runs tests against a component directory fixture by building
+// the component and asserting the rendered config manifests against a
+// want_name.gen.yaml file in the component leaf directory.
+func testComponent(t *testing.T, h *testutil.ComponentHarness, kind, name string) {
+	t.Run(testutil.Capitalize(name), func(t *testing.T) {
+		path := filepath.Join("components", kind, name)
+		leaf := filepath.Join(h.Base(), path)
+		c := h.Component(path)
+		msg := fmt.Sprintf("Expected %s with %s to render config manifests", path, kind)
+		tm, err := c.TypeMeta()
+		require.NoError(t, err, msg)
+		assert.Equal(t, tm.APIVersion, apiVersion)
+
+		t.Run("Build", func(t *testing.T) {
+			bp, err := c.BuildPlan(tm, holos.NewBuildOpts(h.Root(), leaf, "deploy", t.TempDir()), holos.TagMap{})
+			require.NoError(t, err, msg)
+			err = bp.Build(h.Ctx())
+			require.NoError(t, err, msg)
+
+			// Validate the rendered manifest
+			have, err := h.Load(filepath.Join("deploy", "components", kind, name, fmt.Sprintf("%s.gen.yaml", name)))
+			require.NoError(t, err, msg)
+			want, err := h.Load(filepath.Join(leaf, fmt.Sprintf("want_%s.gen.yaml", name)))
+			require.NoError(t, err, msg)
+
+			// Validate in both directions
+			assert.Equal(t, want, have, msg)
+			assert.Equal(t, have, want, msg)
+		})
+	})
+}

--- a/internal/component/v1beta1/components_test.go
+++ b/internal/component/v1beta1/components_test.go
@@ -62,7 +62,7 @@ func TestComponents(t *testing.T) {
 					msg := fmt.Sprintf("Expected %s with %s to fail validation", path, kind)
 					tm, err := c.TypeMeta()
 					require.NoError(t, err, msg)
-					assert.Equal(t, tm.APIVersion, apiVersion)
+					assert.Equal(t, apiVersion, tm.APIVersion)
 
 					t.Run("Build", func(t *testing.T) {
 						opts := holos.NewBuildOpts(h.Root(), leaf, "deploy", t.TempDir())
@@ -94,7 +94,7 @@ func testComponent(t *testing.T, h *testutil.ComponentHarness, kind, name string
 		msg := fmt.Sprintf("Expected %s with %s to render config manifests", path, kind)
 		tm, err := c.TypeMeta()
 		require.NoError(t, err, msg)
-		assert.Equal(t, tm.APIVersion, apiVersion)
+		assert.Equal(t, apiVersion, tm.APIVersion)
 
 		t.Run("Build", func(t *testing.T) {
 			bp, err := c.BuildPlan(tm, holos.NewBuildOpts(h.Root(), leaf, "deploy", t.TempDir()), holos.TagMap{})

--- a/internal/testutil/fixtures/v1beta1/components/alpha6/simple/buildplan.cue
+++ b/internal/testutil/fixtures/v1beta1/components/alpha6/simple/buildplan.cue
@@ -1,0 +1,35 @@
+package holos
+
+import (
+	"encoding/json"
+	"github.com/holos-run/holos/api/core/v1alpha6:core"
+)
+
+// A v1alpha6 component colocated in the v1beta1 fixture tree so the mixed
+// platform1 fixture proves one platform renders components with different
+// api versions in one invocation.
+
+holos: core.#BuildPlan & {
+	metadata: {
+		name: "simple"
+		labels: "holos.run/component.name":       name
+		annotations: "app.holos.run/description": "\(name) command generator"
+	}
+	spec: artifacts: [{
+		artifact: "components/alpha6/\(metadata.name)/\(metadata.name).gen.yaml"
+		generators: [{
+			kind:   "Command"
+			output: artifact
+			command: {
+				args: ["/bin/echo", json.Marshal(_ConfigMap)]
+				isStdoutOutput: true
+			}
+		}]
+	}]
+}
+
+_ConfigMap: {
+	apiVersion: "v1"
+	kind:       "ConfigMap"
+	metadata: name: holos.metadata.name
+}

--- a/internal/testutil/fixtures/v1beta1/components/alpha6/simple/typemeta.cue
+++ b/internal/testutil/fixtures/v1beta1/components/alpha6/simple/typemeta.cue
@@ -1,0 +1,16 @@
+@extern(embed)
+package holos
+
+import (
+	"encoding/json"
+	"github.com/holos-run/holos/api/core/v1alpha6:core"
+)
+
+_BuildContext: string | *"{}" @tag(holos_build_context, type=string)
+BuildContext:  core.#BuildContext & json.Unmarshal(_BuildContext)
+
+holos: core.#BuildPlan & {
+	buildContext: BuildContext
+}
+
+holos: _ @embed(file=typemeta.yaml)

--- a/internal/testutil/fixtures/v1beta1/components/alpha6/simple/typemeta.yaml
+++ b/internal/testutil/fixtures/v1beta1/components/alpha6/simple/typemeta.yaml
@@ -1,0 +1,2 @@
+kind: BuildPlan
+apiVersion: v1alpha6

--- a/internal/testutil/fixtures/v1beta1/components/componentconfig.cue
+++ b/internal/testutil/fixtures/v1beta1/components/componentconfig.cue
@@ -1,0 +1,72 @@
+package holos
+
+import (
+	"encoding/json"
+
+	"github.com/holos-run/holos/api/core/v1beta1:core"
+	"github.com/holos-run/holos/api/author/v1beta1:author"
+)
+
+#ComponentConfig: author.#ComponentConfig & {
+	Name:      _Tags.component.name
+	Path:      _Tags.component.path
+	Resources: #Resources
+
+	// Inject the output base directory from platform component parameters.
+	OutputBaseDir: string | *"" @tag(outputBaseDir, type=string)
+
+	// labels is an optional field, guard references to it.
+	if _Tags.component.labels != _|_ {
+		Labels: _Tags.component.labels
+	}
+
+	// annotations is an optional field, guard references to it.
+	if _Tags.component.annotations != _|_ {
+		Annotations: _Tags.component.annotations
+	}
+}
+
+// https://holos.run/docs/api/author/v1beta1/#Kubernetes
+#Kubernetes: close({
+	#ComponentConfig
+	author.#Kubernetes
+})
+
+// https://holos.run/docs/api/author/v1beta1/#Kustomize
+#Kustomize: close({
+	#ComponentConfig
+	author.#Kustomize
+})
+
+// https://holos.run/docs/api/author/v1beta1/#Helm
+#Helm: close({
+	#ComponentConfig
+	author.#Helm
+})
+
+// Note: tags should have a reasonable default value for cue export.
+_Tags: {
+	// Standardized parameters
+	component: core.#Component & {
+		name: string | *"no-name" @tag(holos_component_name, type=string)
+		path: string | *"no-path" @tag(holos_component_path, type=string)
+
+		_labels_json: string | *"" @tag(holos_component_labels, type=string)
+		_labels: {}
+		if _labels_json != "" {
+			_labels: json.Unmarshal(_labels_json)
+		}
+		for k, v in _labels {
+			labels: (k): v
+		}
+
+		_annotations_json: string | *"" @tag(holos_component_annotations, type=string)
+		_annotations: {}
+		if _annotations_json != "" {
+			_annotations: json.Unmarshal(_annotations_json)
+		}
+		for k, v in _annotations {
+			annotations: (k): v
+		}
+	}
+}

--- a/internal/testutil/fixtures/v1beta1/components/minimal/taskset.cue
+++ b/internal/testutil/fixtures/v1beta1/components/minimal/taskset.cue
@@ -1,0 +1,5 @@
+package holos
+
+holos: {
+	metadata: name: "minimal"
+}

--- a/internal/testutil/fixtures/v1beta1/components/minimal/typemeta.cue
+++ b/internal/testutil/fixtures/v1beta1/components/minimal/typemeta.cue
@@ -1,0 +1,16 @@
+@extern(embed)
+package holos
+
+import (
+	"encoding/json"
+	"github.com/holos-run/holos/api/core/v1beta1:core"
+)
+
+_BuildContext: string | *"{}" @tag(holos_build_context, type=string)
+BuildContext:  core.#BuildContext & json.Unmarshal(_BuildContext)
+
+holos: core.#TaskSet & {
+	buildContext: BuildContext
+}
+
+holos: _ @embed(file=typemeta.yaml)

--- a/internal/testutil/fixtures/v1beta1/components/minimal/typemeta.yaml
+++ b/internal/testutil/fixtures/v1beta1/components/minimal/typemeta.yaml
@@ -1,0 +1,2 @@
+kind: TaskSet
+apiVersion: v1beta1

--- a/internal/testutil/fixtures/v1beta1/components/task/command/taskset.cue
+++ b/internal/testutil/fixtures/v1beta1/components/task/command/taskset.cue
@@ -1,0 +1,39 @@
+package holos
+
+import (
+	"encoding/json"
+	"github.com/holos-run/holos/api/core/v1beta1:core"
+)
+
+// Example of a simple v1beta1 command task.
+
+holos: core.#TaskSet & {
+	metadata: {
+		name: "command"
+		labels: "holos.run/component.name":       name
+		annotations: "app.holos.run/description": "\(name) command task"
+	}
+	spec: tasks: {
+		echo: {
+			kind:   "Command"
+			output: "command.gen.yaml"
+			command: {
+				args: ["/bin/echo", json.Marshal(_ConfigMap)]
+				isStdoutOutput: true
+			}
+		}
+		// Artifact sink per schema.md D2 wiring the output to the final
+		// artifact path relative to the write-to directory.
+		deploy: {
+			kind: "Artifact"
+			inputs: ["command.gen.yaml"]
+			artifact: path: "components/task/command/command.gen.yaml"
+		}
+	}
+}
+
+_ConfigMap: {
+	apiVersion: "v1"
+	kind:       "ConfigMap"
+	metadata: name: holos.metadata.name
+}

--- a/internal/testutil/fixtures/v1beta1/components/task/command/typemeta.cue
+++ b/internal/testutil/fixtures/v1beta1/components/task/command/typemeta.cue
@@ -1,0 +1,16 @@
+@extern(embed)
+package holos
+
+import (
+	"encoding/json"
+	"github.com/holos-run/holos/api/core/v1beta1:core"
+)
+
+_BuildContext: string | *"{}" @tag(holos_build_context, type=string)
+BuildContext:  core.#BuildContext & json.Unmarshal(_BuildContext)
+
+holos: core.#TaskSet & {
+	buildContext: BuildContext
+}
+
+holos: _ @embed(file=typemeta.yaml)

--- a/internal/testutil/fixtures/v1beta1/components/task/command/typemeta.yaml
+++ b/internal/testutil/fixtures/v1beta1/components/task/command/typemeta.yaml
@@ -1,0 +1,2 @@
+kind: TaskSet
+apiVersion: v1beta1

--- a/internal/testutil/fixtures/v1beta1/components/task/command/want_command.gen.yaml
+++ b/internal/testutil/fixtures/v1beta1/components/task/command/want_command.gen.yaml
@@ -1,0 +1,1 @@
+{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"command"}}

--- a/internal/testutil/fixtures/v1beta1/components/task/dag/taskset.cue
+++ b/internal/testutil/fixtures/v1beta1/components/task/dag/taskset.cue
@@ -1,0 +1,53 @@
+package holos
+
+import "github.com/holos-run/holos/api/core/v1beta1:core"
+
+// Diamond shaped DAG: two independent producers join into one output, a
+// command validator gates the artifact sink through an explicit dependsOn
+// edge per schema.md D2.
+
+holos: core.#TaskSet & {
+	metadata: {
+		name: "dag"
+		labels: "holos.run/component.name":       name
+		annotations: "app.holos.run/description": "\(name) diamond"
+	}
+	spec: tasks: {
+		alfa: {
+			kind:   "Resources"
+			output: "alfa.gen.yaml"
+			resources: ConfigMap: alfa: {
+				apiVersion: "v1"
+				kind:       "ConfigMap"
+				metadata: name: "dag-alfa"
+			}
+		}
+		bravo: {
+			kind:   "Resources"
+			output: "bravo.gen.yaml"
+			resources: ConfigMap: bravo: {
+				apiVersion: "v1"
+				kind:       "ConfigMap"
+				metadata: name: "dag-bravo"
+			}
+		}
+		combine: {
+			kind: "Join"
+			inputs: ["alfa.gen.yaml", "bravo.gen.yaml"]
+			output: "dag.gen.yaml"
+			join: separator: "---\n"
+		}
+		// A command with only inputs validates, gating the sink below.
+		validate: {
+			kind: "Command"
+			inputs: ["dag.gen.yaml"]
+			command: args: ["true"]
+		}
+		deploy: {
+			kind: "Artifact"
+			inputs: ["dag.gen.yaml"]
+			dependsOn: validate: {}
+			artifact: path: "components/task/dag/dag.gen.yaml"
+		}
+	}
+}

--- a/internal/testutil/fixtures/v1beta1/components/task/dag/typemeta.cue
+++ b/internal/testutil/fixtures/v1beta1/components/task/dag/typemeta.cue
@@ -1,0 +1,16 @@
+@extern(embed)
+package holos
+
+import (
+	"encoding/json"
+	"github.com/holos-run/holos/api/core/v1beta1:core"
+)
+
+_BuildContext: string | *"{}" @tag(holos_build_context, type=string)
+BuildContext:  core.#BuildContext & json.Unmarshal(_BuildContext)
+
+holos: core.#TaskSet & {
+	buildContext: BuildContext
+}
+
+holos: _ @embed(file=typemeta.yaml)

--- a/internal/testutil/fixtures/v1beta1/components/task/dag/typemeta.yaml
+++ b/internal/testutil/fixtures/v1beta1/components/task/dag/typemeta.yaml
@@ -1,0 +1,2 @@
+kind: TaskSet
+apiVersion: v1beta1

--- a/internal/testutil/fixtures/v1beta1/components/task/dag/want_dag.gen.yaml
+++ b/internal/testutil/fixtures/v1beta1/components/task/dag/want_dag.gen.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: dag-alfa
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: dag-bravo

--- a/internal/testutil/fixtures/v1beta1/components/task/helm/taskset.cue
+++ b/internal/testutil/fixtures/v1beta1/components/task/helm/taskset.cue
@@ -1,0 +1,27 @@
+package holos
+
+import "github.com/holos-run/holos/api/core/v1beta1:core"
+
+holos: core.#TaskSet & {
+	metadata: {
+		name: "helm"
+		labels: "holos.run/component.name":       name
+		annotations: "app.holos.run/description": "\(name) task"
+	}
+	spec: tasks: {
+		helm: {
+			kind:   "Helm"
+			output: "helm.gen.yaml"
+			helm: chart: {
+				name:    "mychart"
+				version: "0.1.0"
+				release: holos.metadata.name
+			}
+		}
+		deploy: {
+			kind: "Artifact"
+			inputs: ["helm.gen.yaml"]
+			artifact: path: "components/task/helm/helm.gen.yaml"
+		}
+	}
+}

--- a/internal/testutil/fixtures/v1beta1/components/task/helm/typemeta.cue
+++ b/internal/testutil/fixtures/v1beta1/components/task/helm/typemeta.cue
@@ -1,0 +1,16 @@
+@extern(embed)
+package holos
+
+import (
+	"encoding/json"
+	"github.com/holos-run/holos/api/core/v1beta1:core"
+)
+
+_BuildContext: string | *"{}" @tag(holos_build_context, type=string)
+BuildContext:  core.#BuildContext & json.Unmarshal(_BuildContext)
+
+holos: core.#TaskSet & {
+	buildContext: BuildContext
+}
+
+holos: _ @embed(file=typemeta.yaml)

--- a/internal/testutil/fixtures/v1beta1/components/task/helm/typemeta.yaml
+++ b/internal/testutil/fixtures/v1beta1/components/task/helm/typemeta.yaml
@@ -1,0 +1,2 @@
+kind: TaskSet
+apiVersion: v1beta1

--- a/internal/testutil/fixtures/v1beta1/components/task/helm/vendor/0.1.0/mychart/.helmignore
+++ b/internal/testutil/fixtures/v1beta1/components/task/helm/vendor/0.1.0/mychart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/internal/testutil/fixtures/v1beta1/components/task/helm/vendor/0.1.0/mychart/Chart.yaml
+++ b/internal/testutil/fixtures/v1beta1/components/task/helm/vendor/0.1.0/mychart/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: mychart
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/internal/testutil/fixtures/v1beta1/components/task/helm/vendor/0.1.0/mychart/templates/secret.yaml
+++ b/internal/testutil/fixtures/v1beta1/components/task/helm/vendor/0.1.0/mychart/templates/secret.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret

--- a/internal/testutil/fixtures/v1beta1/components/task/helm/vendor/0.1.0/mychart/values.yaml
+++ b/internal/testutil/fixtures/v1beta1/components/task/helm/vendor/0.1.0/mychart/values.yaml
@@ -1,0 +1,123 @@
+# Default values for mychart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+replicaCount: 1
+
+# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
+image:
+  repository: nginx
+  # This sets the pull policy for images.
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+# This is for the secretes for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+# This is to override the chart name.
+nameOverride: ""
+fullnameOverride: ""
+
+# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# This is for setting Kubernetes Annotations to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+# This is for setting Kubernetes Labels to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
+service:
+  # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+  type: ClusterIP
+  # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
+  port: 80
+
+# This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+
+# This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/internal/testutil/fixtures/v1beta1/components/task/helm/want_helm.gen.yaml
+++ b/internal/testutil/fixtures/v1beta1/components/task/helm/want_helm.gen.yaml
@@ -1,0 +1,6 @@
+---
+# Source: mychart/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret

--- a/internal/testutil/fixtures/v1beta1/components/task/join/taskset.cue
+++ b/internal/testutil/fixtures/v1beta1/components/task/join/taskset.cue
@@ -1,0 +1,51 @@
+package holos
+
+import (
+	"encoding/json"
+	"github.com/holos-run/holos/api/core/v1beta1:core"
+)
+
+// Example of two producer tasks joined into one output.
+
+holos: core.#TaskSet & {
+	metadata: {
+		name: "join"
+		labels: "holos.run/component.name":       name
+		annotations: "app.holos.run/description": "\(name) task"
+	}
+	spec: tasks: {
+		alfa: {
+			kind:   "Command"
+			output: "alfa.gen.yaml"
+			command: {
+				args: ["/bin/echo", json.Marshal(_ConfigMap & {metadata: name: "join-alfa"})]
+				isStdoutOutput: true
+			}
+		}
+		bravo: {
+			kind:   "Command"
+			output: "bravo.gen.yaml"
+			command: {
+				args: ["/bin/echo", json.Marshal(_ConfigMap & {metadata: name: "join-bravo"})]
+				isStdoutOutput: true
+			}
+		}
+		combine: {
+			kind: "Join"
+			inputs: ["alfa.gen.yaml", "bravo.gen.yaml"]
+			output: "join.gen.yaml"
+			join: separator: "---\n"
+		}
+		deploy: {
+			kind: "Artifact"
+			inputs: ["join.gen.yaml"]
+			artifact: path: "components/task/join/join.gen.yaml"
+		}
+	}
+}
+
+_ConfigMap: {
+	apiVersion: "v1"
+	kind:       "ConfigMap"
+	metadata: name: string
+}

--- a/internal/testutil/fixtures/v1beta1/components/task/join/typemeta.cue
+++ b/internal/testutil/fixtures/v1beta1/components/task/join/typemeta.cue
@@ -1,0 +1,16 @@
+@extern(embed)
+package holos
+
+import (
+	"encoding/json"
+	"github.com/holos-run/holos/api/core/v1beta1:core"
+)
+
+_BuildContext: string | *"{}" @tag(holos_build_context, type=string)
+BuildContext:  core.#BuildContext & json.Unmarshal(_BuildContext)
+
+holos: core.#TaskSet & {
+	buildContext: BuildContext
+}
+
+holos: _ @embed(file=typemeta.yaml)

--- a/internal/testutil/fixtures/v1beta1/components/task/join/typemeta.yaml
+++ b/internal/testutil/fixtures/v1beta1/components/task/join/typemeta.yaml
@@ -1,0 +1,2 @@
+kind: TaskSet
+apiVersion: v1beta1

--- a/internal/testutil/fixtures/v1beta1/components/task/join/want_join.gen.yaml
+++ b/internal/testutil/fixtures/v1beta1/components/task/join/want_join.gen.yaml
@@ -1,0 +1,3 @@
+{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"join-alfa"}}
+---
+{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"join-bravo"}}

--- a/internal/testutil/fixtures/v1beta1/components/task/kustomize/taskset.cue
+++ b/internal/testutil/fixtures/v1beta1/components/task/kustomize/taskset.cue
@@ -1,0 +1,45 @@
+package holos
+
+import "github.com/holos-run/holos/api/core/v1beta1:core"
+
+// Example of a resources -> command -> kustomize task chain.
+
+holos: core.#TaskSet & {
+	metadata: {
+		name: "kustomize"
+		labels: "holos.run/component.name":       name
+		annotations: "app.holos.run/description": "\(name) task chain"
+	}
+	spec: tasks: {
+		resources: {
+			kind:   "Resources"
+			output: "resources.gen.yaml"
+			"resources": ConfigMap: (holos.metadata.name): {
+				apiVersion: "v1"
+				kind:       "ConfigMap"
+				metadata: name: holos.metadata.name
+			}
+		}
+		copy: {
+			kind: "Command"
+			inputs: ["resources.gen.yaml"]
+			output: "copy.gen.yaml"
+			command: {
+				args: ["cat"]
+				stdin:          "resources.gen.yaml"
+				isStdoutOutput: true
+			}
+		}
+		transform: {
+			kind: "Kustomize"
+			inputs: ["copy.gen.yaml"]
+			output: "kustomize.gen.yaml"
+			kustomize: kustomization: resources: inputs
+		}
+		deploy: {
+			kind: "Artifact"
+			inputs: ["kustomize.gen.yaml"]
+			artifact: path: "components/task/kustomize/kustomize.gen.yaml"
+		}
+	}
+}

--- a/internal/testutil/fixtures/v1beta1/components/task/kustomize/typemeta.cue
+++ b/internal/testutil/fixtures/v1beta1/components/task/kustomize/typemeta.cue
@@ -1,0 +1,16 @@
+@extern(embed)
+package holos
+
+import (
+	"encoding/json"
+	"github.com/holos-run/holos/api/core/v1beta1:core"
+)
+
+_BuildContext: string | *"{}" @tag(holos_build_context, type=string)
+BuildContext:  core.#BuildContext & json.Unmarshal(_BuildContext)
+
+holos: core.#TaskSet & {
+	buildContext: BuildContext
+}
+
+holos: _ @embed(file=typemeta.yaml)

--- a/internal/testutil/fixtures/v1beta1/components/task/kustomize/typemeta.yaml
+++ b/internal/testutil/fixtures/v1beta1/components/task/kustomize/typemeta.yaml
@@ -1,0 +1,2 @@
+kind: TaskSet
+apiVersion: v1beta1

--- a/internal/testutil/fixtures/v1beta1/components/task/kustomize/want_kustomize.gen.yaml
+++ b/internal/testutil/fixtures/v1beta1/components/task/kustomize/want_kustomize.gen.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kustomize

--- a/internal/testutil/fixtures/v1beta1/components/validator/secret/taskset.cue
+++ b/internal/testutil/fixtures/v1beta1/components/validator/secret/taskset.cue
@@ -1,0 +1,43 @@
+package holos
+
+import "github.com/holos-run/holos/api/core/v1beta1:core"
+
+holos: core.#TaskSet & {
+	buildContext: _
+	metadata: {
+		name: "secret"
+		labels: "holos.run/component.name":       name
+		annotations: "app.holos.run/description": "\(name) command validator"
+	}
+	spec: tasks: {
+		resources: {
+			kind:   "Resources"
+			output: "secret.gen.yaml"
+			"resources": Secret: (holos.metadata.name): {
+				apiVersion: "v1"
+				kind:       "Secret"
+				metadata: name: holos.metadata.name
+			}
+		}
+		validate: {
+			kind: "Command"
+			inputs: ["secret.gen.yaml"]
+			command: args: [
+				buildContext.holosExecutable,
+				"cue",
+				"vet",
+				"./fixtures/v1beta1/policy",
+				"--path=\"kind\"",
+				"--path=strings.ToLower(kind)",
+				"--path=metadata.name",
+				"\(buildContext.tempDir)/secret.gen.yaml",
+			]
+		}
+		deploy: {
+			kind: "Artifact"
+			inputs: ["secret.gen.yaml"]
+			dependsOn: validate: {}
+			artifact: path: "components/validator/secret/secret.gen.yaml"
+		}
+	}
+}

--- a/internal/testutil/fixtures/v1beta1/components/validator/secret/typemeta.cue
+++ b/internal/testutil/fixtures/v1beta1/components/validator/secret/typemeta.cue
@@ -1,0 +1,16 @@
+@extern(embed)
+package holos
+
+import (
+	"encoding/json"
+	"github.com/holos-run/holos/api/core/v1beta1:core"
+)
+
+_BuildContext: string | *"{}" @tag(holos_build_context, type=string)
+BuildContext:  core.#BuildContext & json.Unmarshal(_BuildContext)
+
+holos: core.#TaskSet & {
+	buildContext: BuildContext
+}
+
+holos: _ @embed(file=typemeta.yaml)

--- a/internal/testutil/fixtures/v1beta1/components/validator/secret/typemeta.yaml
+++ b/internal/testutil/fixtures/v1beta1/components/validator/secret/typemeta.yaml
@@ -1,0 +1,2 @@
+kind: TaskSet
+apiVersion: v1beta1

--- a/internal/testutil/fixtures/v1beta1/platform1/expected_show_buildplans.yaml
+++ b/internal/testutil/fixtures/v1beta1/platform1/expected_show_buildplans.yaml
@@ -1,0 +1,48 @@
+kind: BuildPlan
+apiVersion: v1alpha6
+metadata:
+  name: simple
+  labels:
+    holos.run/component.name: simple
+  annotations:
+    app.holos.run/description: simple command generator
+spec:
+  artifacts:
+    - artifact: components/alpha6/simple/simple.gen.yaml
+      generators:
+        - kind: Command
+          output: components/alpha6/simple/simple.gen.yaml
+          command:
+            args:
+              - /bin/echo
+              - '{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"simple"}}'
+            isStdoutOutput: true
+buildContext:
+  tempDir: "${TMPDIR_PLACEHOLDER}"
+---
+kind: TaskSet
+apiVersion: v1beta1
+metadata:
+  name: command
+  labels:
+    holos.run/component.name: command
+  annotations:
+    app.holos.run/description: command command task
+spec:
+  tasks:
+    echo:
+      kind: Command
+      output: command.gen.yaml
+      command:
+        args:
+          - /bin/echo
+          - '{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"command"}}'
+        isStdoutOutput: true
+    deploy:
+      kind: Artifact
+      inputs:
+        - command.gen.yaml
+      artifact:
+        path: components/task/command/command.gen.yaml
+buildContext:
+  tempDir: "${TMPDIR_PLACEHOLDER}"

--- a/internal/testutil/fixtures/v1beta1/platform1/platform.cue
+++ b/internal/testutil/fixtures/v1beta1/platform1/platform.cue
@@ -1,0 +1,36 @@
+package holos
+
+// A mixed platform proving per-component backwards compatibility: one
+// v1alpha6 component and one v1beta1 component render in one invocation.
+
+holos: {
+	"apiVersion": "v1beta1"
+	"kind":       "Platform"
+	"metadata": {
+		"name": "default"
+	}
+	"spec": {
+		"components": [
+			{
+				"annotations": {
+					"app.holos.run/description": "simple command generator"
+				}
+				"labels": {
+					"holos.run/component.name": "simple"
+				}
+				"name": "simple"
+				"path": "fixtures/v1beta1/components/alpha6/simple"
+			},
+			{
+				"annotations": {
+					"app.holos.run/description": "command command task"
+				}
+				"labels": {
+					"holos.run/component.name": "command"
+				}
+				"name": "command"
+				"path": "fixtures/v1beta1/components/task/command"
+			},
+		]
+	}
+}

--- a/internal/testutil/fixtures/v1beta1/platform1/typemeta.cue
+++ b/internal/testutil/fixtures/v1beta1/platform1/typemeta.cue
@@ -1,0 +1,6 @@
+@extern(embed)
+package holos
+
+import "github.com/holos-run/holos/api/core/v1beta1:core"
+
+holos: core.#Platform @embed(file=typemeta.yaml)

--- a/internal/testutil/fixtures/v1beta1/platform1/typemeta.yaml
+++ b/internal/testutil/fixtures/v1beta1/platform1/typemeta.yaml
@@ -1,0 +1,2 @@
+kind: Platform
+apiVersion: v1beta1

--- a/internal/testutil/fixtures/v1beta1/policy/validation-schema.cue
+++ b/internal/testutil/fixtures/v1beta1/policy/validation-schema.cue
@@ -1,0 +1,12 @@
+package policy
+
+import apps "k8s.io/api/apps/v1"
+
+// Organize by kind then name to avoid conflicts.
+kind: [KIND=string]: [NAME=string]: {...}
+
+// Block Secret resources. kind will not unify with "Secret"
+kind: secret: [NAME=string]: kind: "Forbidden: Use an ExternalSecret instead: secret/\(NAME)"
+
+// Validate Deployment against Kubernetes type definitions.
+kind: deployment: [_]: apps.#Deployment


### PR DESCRIPTION
## Summary
- Add `internal/testutil/fixtures/v1beta1/` mirroring the v1alpha6 fixture tree converted to TaskSet: `minimal/` (no tasks, builds as no-op), `task/{command,helm,kustomize,join,dag}/` with `want_*.gen.yaml` goldens, `validator/secret/` (command validator rejecting a Secret via the `policy` package), and the mixed `platform1/` fixture combining one v1alpha6 component with one v1beta1 component.
- The `dag` fixture exercises `dependsOn` with a diamond shape: two independent producers → join → command validator → artifact sink gated by an explicit `dependsOn` edge per schema.md D2.
- Add `internal/component/v1beta1/components_test.go` mirroring the v1alpha6 fixture-driven tests via `testutil.ComponentHarness`, including bidirectional golden assertions and the validator error case.
- Add `TestShowBeta1` in `internal/cli/show_test.go`: `holos show buildplans` on the mixed platform emits one v1alpha6 BuildPlan and one v1beta1 TaskSet matching `expected_show_buildplans.yaml`.
- Register `TestSchemas_v1beta1` txtar suite under `cmd/holos/tests/v1beta1/schemas/`: `init.txt` (init platform + show platform + cue vet), `render.txt` (author `#Kubernetes` component renders via `holos render platform`), `mixed.txt` (v1alpha6 + v1beta1 components render in one invocation; show buildplans emits one BuildPlan and one TaskSet).
- Backwards-compatibility gate: zero diffs under `internal/testutil/fixtures/{v1alpha5,v1alpha6}` and `cmd/holos/tests/{cli,v1alpha5}` (`git diff origin/main` over those paths is empty). The existing `TestComponentTypeMetaDefault` covers the no-typemeta → v1alpha5 default.

Fixes HOL-1513

## Test plan
- [x] `make lint` passes
- [x] `make test` passes (full suite, including new `TestComponents`, `TestShowBeta1`, `TestSchemas_v1beta1`)
- [x] Zero diffs under existing v1alpha5/v1alpha6 fixtures, golden files, and txtar scripts