### PR TITLE
api: fix doc comment typos in v1beta1 and v1alpha6

### DIFF
--- a/api/core/v1alpha6/types.go
+++ b/api/core/v1alpha6/types.go
@@ -186,7 +186,8 @@ type Artifact struct {
 //  3. [File] - Generates data by reading a file from the component directory.
 //  4. [Command] - Generates data by executing a user-defined command.
 type Generator struct {
-	// Kind represents the kind of generator.  Must be Resources, Helm, or File.
+	// Kind represents the kind of generator.  Must be Resources, Helm, File, or
+	// Command.
 	Kind string `json:"kind" yaml:"kind" cue:"\"Resources\" | \"Helm\" | \"File\" | \"Command\""`
 	// Output represents a file for a Transformer or Artifact to consume.
 	Output FileOrDirectoryPath `json:"output" yaml:"output"`
@@ -302,7 +303,8 @@ type AuthSource struct {
 //
 // [Introduction to Kustomize]: https://kubectl.docs.kubernetes.io/guides/config_management/introduction/
 type Transformer struct {
-	// Kind represents the kind of transformer. Must be Kustomize, or Join.
+	// Kind represents the kind of transformer.  Must be Kustomize, Join, or
+	// Command.
 	Kind string `json:"kind" yaml:"kind" cue:"\"Kustomize\" | \"Join\" | \"Command\""`
 	// Inputs represents the files to transform. The Output of prior Generators
 	// and Transformers.
@@ -360,7 +362,7 @@ type FileContent string
 //
 // [validators]: https://holos.run/docs/v1alpha6/tutorial/validators/
 type Validator struct {
-	// Kind represents the kind of transformer. Must be Kustomize, or Join.
+	// Kind represents the kind of validator.  Must be Command.
 	Kind string `json:"kind" yaml:"kind" cue:"\"Command\""`
 	// Inputs represents the files to validate.  Usually the final Artifact.
 	Inputs []FileOrDirectoryPath `json:"inputs" yaml:"inputs"`
@@ -368,10 +370,10 @@ type Validator struct {
 	Command Command `json:"command,omitempty" yaml:"command,omitempty"`
 }
 
-// Command represents a [BuildPlan] task implemented by executing an user
-// defined system command.  A task is defined as a [Generator], [Transformer],
-// or [Validator].  Commands are executed with the working directory set to the
-// platform root.
+// Command represents a [BuildPlan] task implemented by executing a
+// user-defined system command.  A task is defined as a [Generator],
+// [Transformer], or [Validator].  Commands are executed with the working
+// directory set to the platform root.
 type Command struct {
 	// DisplayName of the command.  The basename of args[0] is used if empty.
 	DisplayName string `json:"displayName,omitempty" yaml:"displayName,omitempty"`

--- a/api/core/v1alpha6/types.go
+++ b/api/core/v1alpha6/types.go
@@ -184,7 +184,7 @@ type Artifact struct {
 //  1. [Resources] - Generates resources from CUE code.
 //  2. [Helm] - Generates rendered yaml from a [Chart].
 //  3. [File] - Generates data by reading a file from the component directory.
-//  4. [Command] - Generates data by executing an user defined command.
+//  4. [Command] - Generates data by executing a user-defined command.
 type Generator struct {
 	// Kind represents the kind of generator.  Must be Resources, Helm, or File.
 	Kind string `json:"kind" yaml:"kind" cue:"\"Resources\" | \"Helm\" | \"File\" | \"Command\""`
@@ -228,7 +228,7 @@ type Helm struct {
 	// Values represents values for holos to marshal into values.yaml when
 	// rendering the chart.  Values follow ValueFiles when both are provided.
 	Values Values `json:"values" yaml:"values"`
-	// ValueFiles represents hierarchial value files passed in order to the helm
+	// ValueFiles represents hierarchical value files passed in order to the helm
 	// template -f flag.  Useful for migration from an ApplicationSet.  Use Values
 	// instead.  ValueFiles precede Values when both are provided.
 	ValueFiles []ValueFile `json:"valueFiles,omitempty" yaml:"valueFiles,omitempty"`
@@ -298,7 +298,7 @@ type AuthSource struct {
 //  1. [Kustomize] - Patch and transform the output from prior generators or
 //     transformers.  See [Introduction to Kustomize].
 //  2. [Join] - Concatenate multiple prior outputs into one output.
-//  3. [Command] - Transforms data by executing an user defined command.
+//  3. [Command] - Transforms data by executing a user-defined command.
 //
 // [Introduction to Kustomize]: https://kubectl.docs.kubernetes.io/guides/config_management/introduction/
 type Transformer struct {

--- a/api/core/v1alpha6/types.go
+++ b/api/core/v1alpha6/types.go
@@ -440,11 +440,11 @@ type Component struct {
 	// Path represents the path of the component relative to the platform root.
 	// Injected as the tag variable "holos_component_path".
 	Path string `json:"path" yaml:"path"`
-	// Parameters represent user defined input variables to produce various
+	// Parameters represent user-defined input variables to produce various
 	// [BuildPlan] resources from one component path.  Injected as CUE @tag
 	// variables.  Parameters with a "holos_" prefix are reserved for use by the
 	// Holos Authors.  Multiple environments are a prime example of an input
-	// parameter that should always be user defined, never defined by Holos.
+	// parameter that should always be user-defined, never defined by Holos.
 	Parameters map[string]string `json:"parameters,omitempty" yaml:"parameters,omitempty"`
 	// Labels represent selector labels for the component.  Holos copies Labels
 	// from the Component to the resulting BuildPlan.

--- a/api/core/v1beta1/types.go
+++ b/api/core/v1beta1/types.go
@@ -174,7 +174,7 @@ type Task struct {
 // breaking composition.
 type Dependency struct{}
 
-// Command represents a [Task] implemented by executing an user defined system
+// Command represents a [Task] implemented by executing a user-defined system
 // command.  Command is a first-class Task kind in v1beta1.  Commands execute
 // with the working directory set to the platform root.
 //
@@ -229,7 +229,7 @@ type Helm struct {
 	// Values represents values for holos to marshal into values.yaml when
 	// rendering the chart.  Values follow ValueFiles when both are provided.
 	Values Values `json:"values" yaml:"values"`
-	// ValueFiles represents hierarchial value files passed in order to the helm
+	// ValueFiles represents hierarchical value files passed in order to the helm
 	// template -f flag.  Useful for migration from an ApplicationSet.  Use Values
 	// instead.  ValueFiles precede Values when both are provided.
 	ValueFiles []ValueFile `json:"valueFiles,omitempty" yaml:"valueFiles,omitempty"`

--- a/api/core/v1beta1/types.go
+++ b/api/core/v1beta1/types.go
@@ -131,7 +131,7 @@ type TaskSetSpec struct {
 //  3. [File] - Read a file from the component directory.
 //  4. [Kustomize] - Patch and transform prior outputs.
 //  5. [Join] - Concatenate prior outputs.
-//  6. [Command] - Execute a user defined command.
+//  6. [Command] - Execute a user-defined command.
 //  7. [Artifact] - Write the final artifact (sink).
 //
 // The Go type does not enforce the constraint; holos enforces it with
@@ -385,11 +385,11 @@ type Component struct {
 	// Path represents the path of the component relative to the platform root.
 	// Injected as the tag variable "holos_component_path".
 	Path string `json:"path" yaml:"path"`
-	// Parameters represent user defined input variables to produce various
+	// Parameters represent user-defined input variables to produce various
 	// [TaskSet] resources from one component path.  Injected as CUE @tag
 	// variables.  Parameters with a "holos_" prefix are reserved for use by the
 	// Holos Authors.  Multiple environments are a prime example of an input
-	// parameter that should always be user defined, never defined by Holos.
+	// parameter that should always be user-defined, never defined by Holos.
 	Parameters map[string]string `json:"parameters,omitempty" yaml:"parameters,omitempty"`
 	// Labels represent selector labels for the component.  Holos copies Labels
 	// from the Component to the resulting TaskSet.

--- a/doc/md/api/core.md
+++ b/doc/md/api/core.md
@@ -230,11 +230,11 @@ type Component struct {
     // Path represents the path of the component relative to the platform root.
     // Injected as the tag variable "holos_component_path".
     Path string `json:"path" yaml:"path"`
-    // Parameters represent user defined input variables to produce various
+    // Parameters represent user-defined input variables to produce various
     // [TaskSet] resources from one component path.  Injected as CUE @tag
     // variables.  Parameters with a "holos_" prefix are reserved for use by the
     // Holos Authors.  Multiple environments are a prime example of an input
-    // parameter that should always be user defined, never defined by Holos.
+    // parameter that should always be user-defined, never defined by Holos.
     Parameters map[string]string `json:"parameters,omitempty" yaml:"parameters,omitempty"`
     // Labels represent selector labels for the component.  Holos copies Labels
     // from the Component to the resulting TaskSet.
@@ -481,7 +481,7 @@ Exactly one of the kind\-specific config fields must be set, matching Kind:
 3. [File](<#File>) \- Read a file from the component directory.
 4. [Kustomize](<#Kustomize>) \- Patch and transform prior outputs.
 5. [Join](<#Join>) \- Concatenate prior outputs.
-6. [Command](<#Command>) \- Execute a user defined command.
+6. [Command](<#Command>) \- Execute a user\-defined command.
 7. [Artifact](<#Artifact>) \- Write the final artifact \(sink\).
 
 The Go type does not enforce the constraint; holos enforces it with per\-kind guards in the published CUE schema and revalidates it at execution time, along with the per\-kind Inputs and Output cardinality rules.

--- a/doc/md/api/core.md
+++ b/doc/md/api/core.md
@@ -198,7 +198,7 @@ type Chart struct {
 <a name="Command"></a>
 ## type Command {#Command}
 
-Command represents a [Task](<#Task>) implemented by executing an user defined system command. Command is a first\-class Task kind in v1beta1. Commands execute with the working directory set to the platform root.
+Command represents a [Task](<#Task>) implemented by executing a user\-defined system command. Command is a first\-class Task kind in v1beta1. Commands execute with the working directory set to the platform root.
 
 A command with an output generates or transforms; a command with only inputs validates, gating downstream tasks through \[Task.DependsOn\] edges.
 
@@ -314,7 +314,7 @@ type Helm struct {
     // Values represents values for holos to marshal into values.yaml when
     // rendering the chart.  Values follow ValueFiles when both are provided.
     Values Values `json:"values" yaml:"values"`
-    // ValueFiles represents hierarchial value files passed in order to the helm
+    // ValueFiles represents hierarchical value files passed in order to the helm
     // template -f flag.  Useful for migration from an ApplicationSet.  Use Values
     // instead.  ValueFiles precede Values when both are provided.
     ValueFiles []ValueFile `json:"valueFiles,omitempty" yaml:"valueFiles,omitempty"`

--- a/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/core/v1alpha6/types_go_gen.cue
+++ b/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/core/v1alpha6/types_go_gen.cue
@@ -178,7 +178,8 @@ package core
 //  3. [File] - Generates data by reading a file from the component directory.
 //  4. [Command] - Generates data by executing a user-defined command.
 #Generator: {
-	// Kind represents the kind of generator.  Must be Resources, Helm, or File.
+	// Kind represents the kind of generator.  Must be Resources, Helm, File, or
+	// Command.
 	kind: string & ("Resources" | "Helm" | "File" | "Command") @go(Kind)
 
 	// Output represents a file for a Transformer or Artifact to consume.
@@ -310,7 +311,8 @@ package core
 //
 // [Introduction to Kustomize]: https://kubectl.docs.kubernetes.io/guides/config_management/introduction/
 #Transformer: {
-	// Kind represents the kind of transformer. Must be Kustomize, or Join.
+	// Kind represents the kind of transformer.  Must be Kustomize, Join, or
+	// Command.
 	kind: string & ("Kustomize" | "Join" | "Command") @go(Kind)
 
 	// Inputs represents the files to transform. The Output of prior Generators
@@ -374,7 +376,7 @@ package core
 //
 // [validators]: https://holos.run/docs/v1alpha6/tutorial/validators/
 #Validator: {
-	// Kind represents the kind of transformer. Must be Kustomize, or Join.
+	// Kind represents the kind of validator.  Must be Command.
 	kind: string & "Command" @go(Kind)
 
 	// Inputs represents the files to validate.  Usually the final Artifact.
@@ -384,10 +386,10 @@ package core
 	command?: #Command @go(Command)
 }
 
-// Command represents a [BuildPlan] task implemented by executing an user
-// defined system command.  A task is defined as a [Generator], [Transformer],
-// or [Validator].  Commands are executed with the working directory set to the
-// platform root.
+// Command represents a [BuildPlan] task implemented by executing a
+// user-defined system command.  A task is defined as a [Generator],
+// [Transformer], or [Validator].  Commands are executed with the working
+// directory set to the platform root.
 #Command: {
 	// DisplayName of the command.  The basename of args[0] is used if empty.
 	displayName?: string @go(DisplayName)

--- a/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/core/v1alpha6/types_go_gen.cue
+++ b/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/core/v1alpha6/types_go_gen.cue
@@ -283,8 +283,8 @@ package core
 // repository.  Holos gets the username and password from the environment
 // variables represented by the Auth field.
 #Repository: {
-	name?: string @go(Name)
-	url?:  string @go(URL)
+	name:  string @go(Name)
+	url:   string @go(URL)
 	auth?: #Auth  @go(Auth)
 }
 

--- a/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/core/v1alpha6/types_go_gen.cue
+++ b/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/core/v1alpha6/types_go_gen.cue
@@ -464,11 +464,11 @@ package core
 	// Injected as the tag variable "holos_component_path".
 	path: string @go(Path)
 
-	// Parameters represent user defined input variables to produce various
+	// Parameters represent user-defined input variables to produce various
 	// [BuildPlan] resources from one component path.  Injected as CUE @tag
 	// variables.  Parameters with a "holos_" prefix are reserved for use by the
 	// Holos Authors.  Multiple environments are a prime example of an input
-	// parameter that should always be user defined, never defined by Holos.
+	// parameter that should always be user-defined, never defined by Holos.
 	parameters?: {[string]: string} @go(Parameters,map[string]string)
 
 	// Labels represent selector labels for the component.  Holos copies Labels

--- a/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/core/v1alpha6/types_go_gen.cue
+++ b/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/core/v1alpha6/types_go_gen.cue
@@ -176,7 +176,7 @@ package core
 //  1. [Resources] - Generates resources from CUE code.
 //  2. [Helm] - Generates rendered yaml from a [Chart].
 //  3. [File] - Generates data by reading a file from the component directory.
-//  4. [Command] - Generates data by executing an user defined command.
+//  4. [Command] - Generates data by executing a user-defined command.
 #Generator: {
 	// Kind represents the kind of generator.  Must be Resources, Helm, or File.
 	kind: string & ("Resources" | "Helm" | "File" | "Command") @go(Kind)
@@ -227,7 +227,7 @@ package core
 	// rendering the chart.  Values follow ValueFiles when both are provided.
 	values: #Values @go(Values)
 
-	// ValueFiles represents hierarchial value files passed in order to the helm
+	// ValueFiles represents hierarchical value files passed in order to the helm
 	// template -f flag.  Useful for migration from an ApplicationSet.  Use Values
 	// instead.  ValueFiles precede Values when both are provided.
 	valueFiles?: [...#ValueFile] @go(ValueFiles,[]ValueFile)
@@ -282,8 +282,8 @@ package core
 // repository.  Holos gets the username and password from the environment
 // variables represented by the Auth field.
 #Repository: {
-	name:  string @go(Name)
-	url:   string @go(URL)
+	name?: string @go(Name)
+	url?:  string @go(URL)
 	auth?: #Auth  @go(Auth)
 }
 
@@ -306,7 +306,7 @@ package core
 //  1. [Kustomize] - Patch and transform the output from prior generators or
 //     transformers.  See [Introduction to Kustomize].
 //  2. [Join] - Concatenate multiple prior outputs into one output.
-//  3. [Command] - Transforms data by executing an user defined command.
+//  3. [Command] - Transforms data by executing a user-defined command.
 //
 // [Introduction to Kustomize]: https://kubectl.docs.kubernetes.io/guides/config_management/introduction/
 #Transformer: {

--- a/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/core/v1beta1/types_go_gen.cue
+++ b/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/core/v1beta1/types_go_gen.cue
@@ -127,7 +127,7 @@ package core
 //  3. [File] - Read a file from the component directory.
 //  4. [Kustomize] - Patch and transform prior outputs.
 //  5. [Join] - Concatenate prior outputs.
-//  6. [Command] - Execute a user defined command.
+//  6. [Command] - Execute a user-defined command.
 //  7. [Artifact] - Write the final artifact (sink).
 //
 // The Go type does not enforce the constraint; holos enforces it with
@@ -412,11 +412,11 @@ package core
 	// Injected as the tag variable "holos_component_path".
 	path: string @go(Path)
 
-	// Parameters represent user defined input variables to produce various
+	// Parameters represent user-defined input variables to produce various
 	// [TaskSet] resources from one component path.  Injected as CUE @tag
 	// variables.  Parameters with a "holos_" prefix are reserved for use by the
 	// Holos Authors.  Multiple environments are a prime example of an input
-	// parameter that should always be user defined, never defined by Holos.
+	// parameter that should always be user-defined, never defined by Holos.
 	parameters?: {[string]: string} @go(Parameters,map[string]string)
 
 	// Labels represent selector labels for the component.  Holos copies Labels

--- a/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/core/v1beta1/types_go_gen.cue
+++ b/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/core/v1beta1/types_go_gen.cue
@@ -180,7 +180,7 @@ package core
 // breaking composition.
 #Dependency: {}
 
-// Command represents a [Task] implemented by executing an user defined system
+// Command represents a [Task] implemented by executing a user-defined system
 // command.  Command is a first-class Task kind in v1beta1.  Commands execute
 // with the working directory set to the platform root.
 //
@@ -240,7 +240,7 @@ package core
 	// rendering the chart.  Values follow ValueFiles when both are provided.
 	values: #Values @go(Values)
 
-	// ValueFiles represents hierarchial value files passed in order to the helm
+	// ValueFiles represents hierarchical value files passed in order to the helm
 	// template -f flag.  Useful for migration from an ApplicationSet.  Use Values
 	// instead.  ValueFiles precede Values when both are provided.
 	valueFiles?: [...#ValueFile] @go(ValueFiles,[]ValueFile)


### PR DESCRIPTION
## Summary
- Fix "an user defined" -> "a user-defined" in `api/core/v1beta1/types.go` (line 177) and the two corresponding v1alpha6 doc comments
- Fix "hierarchial" -> "hierarchical" in `api/core/v1beta1/types.go` (line 232) and `api/core/v1alpha6/types.go`
- Regenerate docs via `go generate ./api/core/v1beta1/` and the CUE gen tree via `go generate ./internal/generate/platforms`
- Regeneration also syncs stale v1alpha6 gen drift: `Repository.name`/`Repository.url` became optional when `omitempty` was added in df69198c but the gen tree was never regenerated

Fixes HOL-1514

## Test plan
- [ ] `make lint` passes (cspell clean)
- [ ] `make test` passes (all packages ok)
- [ ] `git grep "hierarchial\|an user defined"` returns hits only in frozen v1alpha5 sources and versioned docs