### PR TITLE
api: reconcile v1alpha6 Repository CUE gen drift with OCI-aware validation

### DIFF
--- a/api/core/v1alpha6/types.go
+++ b/api/core/v1alpha6/types.go
@@ -271,6 +271,13 @@ type Chart struct {
 
 // Repository represents a [Helm] [Chart] repository.
 //
+// The URL field is required unless the [Chart] Name field is an oci://
+// reference, in which case holos pulls the chart directly from the OCI
+// registry and the URL field must be omitted.  An OCI chart specifies a
+// Repository only to configure registry authentication with the Auth field.
+// The CUE schema enforces this contract; the Name and URL fields are optional
+// at the Go level to support OCI auth-only repositories.
+//
 // The Auth field is useful to configure http basic authentication to the Helm
 // repository.  Holos gets the username and password from the environment
 // variables represented by the Auth field.

--- a/internal/component/v1alpha6/v1alpha6_test.go
+++ b/internal/component/v1alpha6/v1alpha6_test.go
@@ -41,9 +41,26 @@ func TestComponents(t *testing.T) {
 
 	t.Run("BuildPlan", func(t *testing.T) {
 		t.Run("Generator", func(t *testing.T) {
-			for _, tc := range []string{"simple", "directory", "helm"} {
+			for _, tc := range []string{"simple", "directory", "helm", "helm-oci"} {
 				testComponent(t, h, "generator", tc)
 			}
+
+			t.Run("RepositoryURLRequired", func(t *testing.T) {
+				// A non-OCI chart with a repository missing the url field must
+				// fail CUE validation.
+				path := "components/generator/helm-no-url"
+				leaf := filepath.Join(h.Base(), path)
+				c := h.Component(path)
+				msg := fmt.Sprintf("Expected %s to fail validation, repository url is required for non-oci charts", path)
+				tm, err := c.TypeMeta()
+				require.NoError(t, err, msg)
+				assert.Equal(t, apiVersion, tm.APIVersion, msg)
+
+				_, err = c.BuildPlan(tm, holos.NewBuildOpts(h.Root(), leaf, "deploy", t.TempDir()), holos.TagMap{})
+				require.Error(t, err, msg)
+				assert.ErrorContains(t, err, "repository.url", msg)
+				assert.ErrorContains(t, err, "required", msg)
+			})
 		})
 
 		t.Run("Transformer", func(t *testing.T) {

--- a/internal/component/v1alpha6/v1alpha6_test.go
+++ b/internal/component/v1alpha6/v1alpha6_test.go
@@ -61,6 +61,23 @@ func TestComponents(t *testing.T) {
 				assert.ErrorContains(t, err, "repository.url", msg)
 				assert.ErrorContains(t, err, "required", msg)
 			})
+
+			t.Run("RepositoryURLForbiddenForOCI", func(t *testing.T) {
+				// An OCI chart with a repository url must fail CUE validation,
+				// OCI charts pull directly from the registry.
+				path := "components/generator/helm-oci-url"
+				leaf := filepath.Join(h.Base(), path)
+				c := h.Component(path)
+				msg := fmt.Sprintf("Expected %s to fail validation, repository url must be omitted for oci charts", path)
+				tm, err := c.TypeMeta()
+				require.NoError(t, err, msg)
+				assert.Equal(t, apiVersion, tm.APIVersion, msg)
+
+				_, err = c.BuildPlan(tm, holos.NewBuildOpts(h.Root(), leaf, "deploy", t.TempDir()), holos.TagMap{})
+				require.Error(t, err, msg)
+				assert.ErrorContains(t, err, "repository.url", msg)
+				assert.ErrorContains(t, err, "not allowed", msg)
+			})
 		})
 
 		t.Run("Transformer", func(t *testing.T) {

--- a/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/core/v1alpha6/types_go_gen.cue
+++ b/internal/generate/platforms/cue.mod/gen/github.com/holos-run/holos/api/core/v1alpha6/types_go_gen.cue
@@ -279,12 +279,19 @@ package core
 
 // Repository represents a [Helm] [Chart] repository.
 //
+// The URL field is required unless the [Chart] Name field is an oci://
+// reference, in which case holos pulls the chart directly from the OCI
+// registry and the URL field must be omitted.  An OCI chart specifies a
+// Repository only to configure registry authentication with the Auth field.
+// The CUE schema enforces this contract; the Name and URL fields are optional
+// at the Go level to support OCI auth-only repositories.
+//
 // The Auth field is useful to configure http basic authentication to the Helm
 // repository.  Holos gets the username and password from the environment
 // variables represented by the Auth field.
 #Repository: {
-	name:  string @go(Name)
-	url:   string @go(URL)
+	name?: string @go(Name)
+	url?:  string @go(URL)
 	auth?: #Auth  @go(Auth)
 }
 

--- a/internal/generate/platforms/cue.mod/pkg/github.com/holos-run/holos/api/core/v1alpha6/types.cue
+++ b/internal/generate/platforms/cue.mod/pkg/github.com/holos-run/holos/api/core/v1alpha6/types.cue
@@ -1,0 +1,14 @@
+package core
+
+import "strings"
+
+// A chart repository url is required unless the chart name is an oci://
+// reference.  OCI charts pull directly from the registry and specify a
+// repository only to configure authentication with the auth field.
+#Chart: Chart={
+	repository?: {
+		if !strings.HasPrefix(Chart.name, "oci://") {
+			url!: string
+		}
+	}
+}

--- a/internal/generate/platforms/cue.mod/pkg/github.com/holos-run/holos/api/core/v1alpha6/types.cue
+++ b/internal/generate/platforms/cue.mod/pkg/github.com/holos-run/holos/api/core/v1alpha6/types.cue
@@ -4,11 +4,18 @@ import "strings"
 
 // A chart repository url is required unless the chart name is an oci://
 // reference.  OCI charts pull directly from the registry and specify a
-// repository only to configure authentication with the auth field.
+// repository only to configure authentication with the auth field, so the
+// url field must be omitted.
 #Chart: Chart={
 	repository?: {
 		if !strings.HasPrefix(Chart.name, "oci://") {
 			url!: string
 		}
+	}
+	if strings.HasPrefix(Chart.name, "oci://") {
+		repository?: close({
+			name?: string
+			auth?: #Auth
+		})
 	}
 }

--- a/internal/testutil/fixtures/v1alpha6/components/generator/helm-no-url/buildplan.cue
+++ b/internal/testutil/fixtures/v1alpha6/components/generator/helm-no-url/buildplan.cue
@@ -1,0 +1,26 @@
+package holos
+
+import "github.com/holos-run/holos/api/core/v1alpha6:core"
+
+// A non-OCI chart with a repository missing the url field must fail CUE
+// validation.  See the #Chart constraint in cue.mod/pkg.
+holos: core.#BuildPlan & {
+	metadata: {
+		name: "helm-no-url"
+		labels: "holos.run/component.name":       name
+		annotations: "app.holos.run/description": "\(name) generator"
+	}
+	spec: artifacts: [{
+		artifact: "components/generator/\(metadata.name)/\(metadata.name).gen.yaml"
+		generators: [{
+			kind:   "Helm"
+			output: artifact
+			helm: chart: {
+				name:    "mychart"
+				version: "0.1.0"
+				release: "mychart"
+				repository: name: "myrepo"
+			}
+		}]
+	}]
+}

--- a/internal/testutil/fixtures/v1alpha6/components/generator/helm-no-url/typemeta.cue
+++ b/internal/testutil/fixtures/v1alpha6/components/generator/helm-no-url/typemeta.cue
@@ -1,0 +1,16 @@
+@extern(embed)
+package holos
+
+import (
+	"encoding/json"
+	"github.com/holos-run/holos/api/core/v1alpha6:core"
+)
+
+_BuildContext: string | *"{}" @tag(holos_build_context, type=string)
+BuildContext:  core.#BuildContext & json.Unmarshal(_BuildContext)
+
+holos: core.#BuildPlan & {
+	buildContext: BuildContext
+}
+
+holos: _ @embed(file=typemeta.yaml)

--- a/internal/testutil/fixtures/v1alpha6/components/generator/helm-no-url/typemeta.yaml
+++ b/internal/testutil/fixtures/v1alpha6/components/generator/helm-no-url/typemeta.yaml
@@ -1,0 +1,2 @@
+kind: BuildPlan
+apiVersion: v1alpha6

--- a/internal/testutil/fixtures/v1alpha6/components/generator/helm-oci-url/buildplan.cue
+++ b/internal/testutil/fixtures/v1alpha6/components/generator/helm-oci-url/buildplan.cue
@@ -1,0 +1,27 @@
+package holos
+
+import "github.com/holos-run/holos/api/core/v1alpha6:core"
+
+// An OCI chart with a repository url must fail CUE validation.  OCI charts
+// pull directly from the registry, so the url field must be omitted.  See the
+// #Chart constraint in cue.mod/pkg.
+holos: core.#BuildPlan & {
+	metadata: {
+		name: "helm-oci-url"
+		labels: "holos.run/component.name":       name
+		annotations: "app.holos.run/description": "\(name) generator"
+	}
+	spec: artifacts: [{
+		artifact: "components/generator/\(metadata.name)/\(metadata.name).gen.yaml"
+		generators: [{
+			kind:   "Helm"
+			output: artifact
+			helm: chart: {
+				name:    "oci://registry.example.com/charts/mychart"
+				version: "0.1.0"
+				release: "mychart"
+				repository: url: "https://charts.example.com"
+			}
+		}]
+	}]
+}

--- a/internal/testutil/fixtures/v1alpha6/components/generator/helm-oci-url/typemeta.cue
+++ b/internal/testutil/fixtures/v1alpha6/components/generator/helm-oci-url/typemeta.cue
@@ -1,0 +1,16 @@
+@extern(embed)
+package holos
+
+import (
+	"encoding/json"
+	"github.com/holos-run/holos/api/core/v1alpha6:core"
+)
+
+_BuildContext: string | *"{}" @tag(holos_build_context, type=string)
+BuildContext:  core.#BuildContext & json.Unmarshal(_BuildContext)
+
+holos: core.#BuildPlan & {
+	buildContext: BuildContext
+}
+
+holos: _ @embed(file=typemeta.yaml)

--- a/internal/testutil/fixtures/v1alpha6/components/generator/helm-oci-url/typemeta.yaml
+++ b/internal/testutil/fixtures/v1alpha6/components/generator/helm-oci-url/typemeta.yaml
@@ -1,0 +1,2 @@
+kind: BuildPlan
+apiVersion: v1alpha6

--- a/internal/testutil/fixtures/v1alpha6/components/generator/helm-oci/buildplan.cue
+++ b/internal/testutil/fixtures/v1alpha6/components/generator/helm-oci/buildplan.cue
@@ -1,0 +1,29 @@
+package holos
+
+import "github.com/holos-run/holos/api/core/v1alpha6:core"
+
+// An OCI chart pulls directly from the registry.  The repository omits the url
+// field and configures registry authentication with the auth field.
+holos: core.#BuildPlan & {
+	metadata: {
+		name: "helm-oci"
+		labels: "holos.run/component.name":       name
+		annotations: "app.holos.run/description": "\(name) generator"
+	}
+	spec: artifacts: [{
+		artifact: "components/generator/\(metadata.name)/\(metadata.name).gen.yaml"
+		generators: [{
+			kind:   "Helm"
+			output: artifact
+			helm: chart: {
+				name:    "oci://registry.example.com/charts/mychart"
+				version: "0.1.0"
+				release: "mychart"
+				repository: auth: {
+					username: fromEnv: "HOLOS_TEST_REGISTRY_USERNAME"
+					password: fromEnv: "HOLOS_TEST_REGISTRY_PASSWORD"
+				}
+			}
+		}]
+	}]
+}

--- a/internal/testutil/fixtures/v1alpha6/components/generator/helm-oci/typemeta.cue
+++ b/internal/testutil/fixtures/v1alpha6/components/generator/helm-oci/typemeta.cue
@@ -1,0 +1,16 @@
+@extern(embed)
+package holos
+
+import (
+	"encoding/json"
+	"github.com/holos-run/holos/api/core/v1alpha6:core"
+)
+
+_BuildContext: string | *"{}" @tag(holos_build_context, type=string)
+BuildContext:  core.#BuildContext & json.Unmarshal(_BuildContext)
+
+holos: core.#BuildPlan & {
+	buildContext: BuildContext
+}
+
+holos: _ @embed(file=typemeta.yaml)

--- a/internal/testutil/fixtures/v1alpha6/components/generator/helm-oci/typemeta.yaml
+++ b/internal/testutil/fixtures/v1alpha6/components/generator/helm-oci/typemeta.yaml
@@ -1,0 +1,2 @@
+kind: BuildPlan
+apiVersion: v1alpha6

--- a/internal/testutil/fixtures/v1alpha6/components/generator/helm-oci/vendor/0.1.0/mychart/.helmignore
+++ b/internal/testutil/fixtures/v1alpha6/components/generator/helm-oci/vendor/0.1.0/mychart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/internal/testutil/fixtures/v1alpha6/components/generator/helm-oci/vendor/0.1.0/mychart/Chart.yaml
+++ b/internal/testutil/fixtures/v1alpha6/components/generator/helm-oci/vendor/0.1.0/mychart/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: mychart
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/internal/testutil/fixtures/v1alpha6/components/generator/helm-oci/vendor/0.1.0/mychart/templates/secret.yaml
+++ b/internal/testutil/fixtures/v1alpha6/components/generator/helm-oci/vendor/0.1.0/mychart/templates/secret.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret

--- a/internal/testutil/fixtures/v1alpha6/components/generator/helm-oci/vendor/0.1.0/mychart/values.yaml
+++ b/internal/testutil/fixtures/v1alpha6/components/generator/helm-oci/vendor/0.1.0/mychart/values.yaml
@@ -1,0 +1,123 @@
+# Default values for mychart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+replicaCount: 1
+
+# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
+image:
+  repository: nginx
+  # This sets the pull policy for images.
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+# This is for the secretes for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+# This is to override the chart name.
+nameOverride: ""
+fullnameOverride: ""
+
+# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# This is for setting Kubernetes Annotations to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+# This is for setting Kubernetes Labels to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
+service:
+  # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+  type: ClusterIP
+  # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
+  port: 80
+
+# This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+
+# This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/internal/testutil/fixtures/v1alpha6/components/generator/helm-oci/want_helm-oci.gen.yaml
+++ b/internal/testutil/fixtures/v1alpha6/components/generator/helm-oci/want_helm-oci.gen.yaml
@@ -1,0 +1,6 @@
+---
+# Source: mychart/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret


### PR DESCRIPTION
## Summary
- Regenerate the v1alpha6 CUE gen tree so it matches the Go source after commit df69198c made `Repository.Name`/`Repository.URL` omitempty; a plain `go generate ./internal/generate/platforms` run now produces no diff.
- Document the intended contract on `Repository` in `api/core/v1alpha6/types.go`: `url` is required unless the chart name is an `oci://` reference; OCI charts specify a repository only to configure registry authentication.
- Enforce the contract with a `cue.mod/pkg` overlay constraint on `#Chart` (`internal/generate/platforms/cue.mod/pkg/github.com/holos-run/holos/api/core/v1alpha6/types.cue`): when a repository is present and the chart name is not `oci://`, `repository.url` is a required field. The guard flows through both `core.#BuildPlan` and `author.#Helm`.
- Add fixtures and tests: `helm-no-url` (non-OCI chart with repository missing url, rejected with `repository.url: field is required but not present`) and `helm-oci` (OCI chart with auth-only repository, accepted and rendered offline from the vendored chart).

Fixes HOL-1516

## Test plan
- [x] `go test ./internal/component/v1alpha6/...` — new `Generator/Helm-oci` and `Generator/RepositoryURLRequired` subtests pass
- [x] `make lint` and `make test` pass
- [x] `go generate ./internal/generate/platforms` produces no diff
- [x] `cue vet` spot checks: non-OCI missing url rejected; OCI auth-only accepted; chart with no repository at all still accepted (local/vendored charts)

## Notes
- v1beta1 shares the same optional `name`/`url` fields but its gen tree is not stale; mirroring this guard to v1beta1 is left for the v1beta1 schema work.